### PR TITLE
P1: indexes for keyset + query alignment

### DIFF
--- a/migrations/versions/5d74d73e056c_add_keyset_indexes_for_gyms_gym_.py
+++ b/migrations/versions/5d74d73e056c_add_keyset_indexes_for_gyms_gym_.py
@@ -1,0 +1,45 @@
+"""add keyset indexes for gyms/gym_equipments/equipments
+
+Revision ID: 5d74d73e056c
+Revises: 784e740115be
+Create Date: 2025-09-06 12:18:13.075591
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5d74d73e056c'
+down_revision: Union[str, None] = '784e740115be'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    # 既存掃除（制約→インデックスの順で）
+    op.execute("ALTER TABLE equipments DROP CONSTRAINT IF EXISTS uq_equipments_slug")
+    op.execute("DROP INDEX IF EXISTS ix_equipments_id")
+    op.execute("DROP INDEX IF EXISTS ix_equipments_slug")
+    # op.execute("DROP INDEX IF EXISTS ix_equipments_slug_trgm")  # 使わないなら
+
+    # ここに gyms / gym_equipments の create_index が続く想定
+    op.create_index(
+        "ix_gyms_pref_city_lvac_id",
+        "gyms",
+        ["pref","city", sa.text("last_verified_at_cached DESC NULLS LAST"), sa.text("id ASC")],
+        unique=False,
+    )
+    op.create_index(
+        "ix_gym_equipments_gym_equipment",
+        "gym_equipments",
+        ["gym_id", "equipment_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index("ix_gym_equipments_gym_equipment", table_name="gym_equipments")
+    op.drop_index("ix_gyms_pref_city_lvac_id", table_name="gyms")


### PR DESCRIPTION
## 目的
P1: Keysetページングを支えるクエリ/インデックス最適化

## 変更
- gyms: `(pref, city, last_verified_at_cached DESC NULLS LAST, id ASC)` の btree 追加
- gym_equipments: `(gym_id, equipment_id)` の btree 追加
- equipments: 重複インデックス/制約の掃除  
  - DROP: `uq_equipments_slug`, `ix_equipments_slug`, `ix_equipments_id`（trgmは温存）
- freshness 検索を **列ベースの ORDER** に統一  
  - ORDER: `last_verified_at_cached DESC NULLS LAST, id ASC`
  - keyset token: `{"sort":"freshness","k":[ts_iso_or_null, id]}` (Base64)
- WHERE 条件は列側に `lower()` を掛けず、入力だけ小文字化（インデックスヒット）

## 確認
- `alembic upgrade head` 成功
- EXPLAIN: `Index Scan using ix_gyms_pref_city_lvac_id` を確認
- 代表curlでページング前進/has_next動作OK

## 影響範囲
- APIレスポンス仕様は変更なし（P0ですでに `pref` 統一）
- DBレベルはインデックス整備と不要インデックス/制約の削除のみ
MD