### PR TITLE
feat(repository): add GymRepository and refactor services to use it

### DIFF
--- a/app/api/routers/gyms.py
+++ b/app/api/routers/gyms.py
@@ -17,7 +17,6 @@ from app.models import Equipment, Gym, GymEquipment
 from app.schemas.common import ErrorResponse
 from app.schemas.gym_detail import GymDetailResponse
 from app.schemas.gym_search import GymSearchResponse, GymSummary
-from app.services.scoring import compute_bundle
 
 router = APIRouter(prefix="/gyms", tags=["gyms"])
 
@@ -529,57 +528,7 @@ async def get_gym_detail(
     include: str | None = Query(default=None, description="例: include=score"),
     session: AsyncSession = Depends(get_async_session),
 ):
-    gym = (await session.execute(select(Gym).where(Gym.slug == slug))).scalar_one_or_none()
-    if not gym:
-        raise HTTPException(status_code=404, detail="gym not found")
-    # --- equipments を JOIN して配列に構築 ---
-    eq_rows = await session.execute(
-        select(
-            Equipment.slug,
-            Equipment.name,
-            Equipment.category,
-            GymEquipment.count,
-            GymEquipment.max_weight_kg,
-        )
-        .join(GymEquipment, GymEquipment.equipment_id == Equipment.id)
-        .where(GymEquipment.gym_id == gym.id)
-        .order_by(Equipment.name)
-    )
-    equipments_list = [
-        {
-            "equipment_slug": slug,
-            "equipment_name": name,
-            "category": category,
-            "count": count,
-            "max_weight_kg": max_w,
-        }
-        for (slug, name, category, count, max_w) in eq_rows.all()
-    ]
+    # Delegate to service which uses GymRepository under the hood
+    from app.services.gym_detail import get_gym_detail as svc_get_gym_detail
 
-    # Pydantic v2: 必要キーを手組みしてから validate
-    # 必須フィールドを明示的に埋めてから validate（Pydantic v2）
-    data = {
-        "id": gym.id,
-        "slug": gym.slug,
-        "name": gym.name,
-        "pref": getattr(gym, "pref", None),
-        "city": gym.city,
-        # 必須の updated_at / last_verified_at は ISO 文字列に統一
-        "updated_at": gym.updated_at.isoformat() if getattr(gym, "updated_at", None) else None,
-        "last_verified_at": gym.last_verified_at_cached.isoformat()
-        if getattr(gym, "last_verified_at_cached", None)
-        else None,
-        # スキーマの item 形に合わせた dict 配列
-        "equipments": equipments_list,
-    }
-
-    if include == "score":
-        num = await _count_equips(session, int(getattr(gym, "id", 0)))
-        mx = await _max_gym_equips(session)
-        bundle = compute_bundle(gym.last_verified_at_cached, num, mx)
-        # 追加フィールドを dict に積む
-        data["freshness"] = bundle.freshness
-        data["richness"] = bundle.richness
-        data["score"] = bundle.score
-
-    return GymDetailResponse.model_validate(data)
+    return await svc_get_gym_detail(session, slug, include)

--- a/app/repositories/gym_repository.py
+++ b/app/repositories/gym_repository.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gym import Gym
+
+
+class GymRepository:
+    """Repository for Gym model.
+
+    Encapsulates DB access for gyms using Async SQLAlchemy session.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session: AsyncSession = session
+
+    async def get_by_id(self, gym_id: int) -> Gym | None:
+        """Fetch a gym by its primary key.
+
+        Args:
+            gym_id: Gym.id
+
+        Returns:
+            Gym instance if found, otherwise None.
+        """
+        return await self._session.get(Gym, gym_id)
+
+    async def search_by_name(self, name: str) -> list[Gym]:
+        """Search gyms whose name contains the given text (case-insensitive).
+
+        Args:
+            name: Partial text to match against `Gym.name`.
+
+        Returns:
+            List of matching Gym entities.
+        """
+        if not name:
+            return []
+
+        stmt = select(Gym).where(Gym.name.ilike(f"%{name}%"))
+        # scalars() returns ScalarResult[Gym]; .all() -> list[Gym]
+        gyms: list[Gym] = (await self._session.scalars(stmt)).all()
+        return gyms
+
+    async def list_by_pref_city(self, *, pref: str | None, city: str | None) -> list[Gym]:
+        """List gyms filtered by pref and city (case-insensitive equality).
+
+        Args:
+            pref: Prefecture slug (lower) or None.
+            city: City slug (lower) or None.
+
+        Returns:
+            List of Gym entities.
+        """
+        stmt = select(Gym)
+        if pref:
+            stmt = stmt.where(func.lower(Gym.pref) == func.lower(pref))
+        if city:
+            stmt = stmt.where(func.lower(Gym.city) == func.lower(city))
+        return (await self._session.scalars(stmt)).all()
+
+    async def get_all_ordered_by_id(self) -> list[Gym]:
+        """Return all gyms ordered by id (ascending)."""
+        return (await self._session.scalars(select(Gym).order_by(Gym.id))).all()

--- a/app/services/gym_detail.py
+++ b/app/services/gym_detail.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Equipment, Gym, GymEquipment
+from app.repositories.gym_repository import GymRepository
+from app.schemas.gym_detail import GymDetailResponse
+from app.services.scoring import compute_bundle
+
+
+async def _count_equips(session: AsyncSession, gym_id: int) -> int:
+    stmt = select(func.count()).select_from(GymEquipment).where(GymEquipment.gym_id == gym_id)
+    return (await session.execute(stmt)).scalar_one()
+
+
+async def _max_gym_equips(session: AsyncSession) -> int:
+    sub = (
+        select(GymEquipment.gym_id, func.count().label("c"))
+        .group_by(GymEquipment.gym_id)
+        .subquery()
+    )
+    stmt = select(func.coalesce(func.max(sub.c.c), 0))
+    return (await session.execute(stmt)).scalar_one()
+
+
+def _iso(dt: datetime | None) -> str | None:
+    if not dt or (hasattr(dt, "year") and dt.year < 1970):
+        return None
+    return dt.isoformat()
+
+
+async def get_gym_detail(
+    session: AsyncSession, slug: str, include: str | None
+) -> GymDetailResponse:
+    # Resolve the gym id by slug first (index on slug exists)
+    gym_id = await session.scalar(select(Gym.id).where(Gym.slug == slug))
+    if not gym_id:
+        raise HTTPException(status_code=404, detail="gym not found")
+
+    # Use repository to load the entity by id
+    repo = GymRepository(session)
+    gym = await repo.get_by_id(int(gym_id))
+    if not gym:
+        # Defensive: id not found after slug resolution (should not happen)
+        raise HTTPException(status_code=404, detail="gym not found")
+
+    # Equipments list
+    eq_rows = await session.execute(
+        select(
+            Equipment.slug,
+            Equipment.name,
+            Equipment.category,
+            GymEquipment.count,
+            GymEquipment.max_weight_kg,
+        )
+        .join(GymEquipment, GymEquipment.equipment_id == Equipment.id)
+        .where(GymEquipment.gym_id == gym.id)
+        .order_by(Equipment.name)
+    )
+    equipments_list = [
+        {
+            "equipment_slug": slug,
+            "equipment_name": name,
+            "category": category,
+            "count": count,
+            "max_weight_kg": max_w,
+        }
+        for (slug, name, category, count, max_w) in eq_rows.all()
+    ]
+
+    data = {
+        "id": int(getattr(gym, "id", 0)),
+        "slug": str(getattr(gym, "slug", "")),
+        "name": str(getattr(gym, "name", "")),
+        "pref": getattr(gym, "pref", None),
+        "city": str(getattr(gym, "city", "")),
+        "updated_at": _iso(getattr(gym, "updated_at", None)),
+        "last_verified_at": _iso(getattr(gym, "last_verified_at_cached", None)),
+        "equipments": equipments_list,
+    }
+
+    if include == "score":
+        num = await _count_equips(session, int(getattr(gym, "id", 0)))
+        mx = await _max_gym_equips(session)
+        bundle = compute_bundle(getattr(gym, "last_verified_at_cached", None), num, mx)
+        data["freshness"] = bundle.freshness
+        data["richness"] = bundle.richness
+        data["score"] = bundle.score
+
+    return GymDetailResponse.model_validate(data)


### PR DESCRIPTION
- Introduce app/repositories/GymRepository with AsyncSession
- Implement get_by_id and search_by_name (ILIKE partial)
- Add list_by_pref_city and get_all_ordered_by_id helpers
- Refactor gym detail route via new service using repository
- Refactor search service to use repository for base fetch and created_at map

Refs: FastAPI + SQLAlchemy(Async); target Python 3.11