### PR TITLE
OpenAPI: Add response_model + summaries across routers

### DIFF
--- a/app/api/routers/healthz.py
+++ b/app/api/routers/healthz.py
@@ -2,11 +2,17 @@
 from fastapi import APIRouter, Depends
 
 from app.api.deps import get_health_service
+from app.schemas.common import OkResponse
 from app.services.health import HealthService
 
 router = APIRouter(prefix="/healthz", tags=["health"])
 
 
-@router.get("", summary="Health check", description="DBにSELECT 1を投げる軽量ヘルスチェック")
+@router.get(
+    "",
+    response_model=OkResponse,
+    summary="Health check",
+    description="DB に SELECT 1 を投げる軽量ヘルスチェック",
+)
 async def healthz(svc: HealthService = Depends(get_health_service)):
     return await svc.ok()

--- a/app/routers/gyms.py
+++ b/app/routers/gyms.py
@@ -14,6 +14,11 @@ router = APIRouter(prefix="/gyms", tags=["gyms"])
 @router.get(
     "/search",
     response_model=schemas.SearchResponse,
+    summary="ジム検索（v1）",
+    description=(
+        "都道府県/市区町村スラッグ、設備スラッグ（CSV）でフィルタ。"
+        "sort は richness/freshness を指定。ページングあり。"
+    ),
     responses={
         400: {
             "description": "Invalid page_token",
@@ -79,7 +84,12 @@ async def search_gyms(
     return schemas.SearchResponse(items=items, page=page, per_page=per_page, total=result["total"])
 
 
-@router.get("/{slug}", response_model=schemas.GymDetailResponse)
+@router.get(
+    "/{slug}",
+    response_model=schemas.GymDetailResponse,
+    summary="ジム詳細（v1）",
+    description="ジムの詳細情報を返します。",
+)
 async def get_gym_detail(slug: str, svc: GymDetailServiceV1 = Depends(get_gym_detail_service_v1)):
     detail = await svc.get(slug)
     if detail is None:

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -6,3 +6,9 @@ class ErrorResponse(BaseModel):
     detail: str = Field(description="エラーメッセージ")
 
     model_config = {"json_schema_extra": {"examples": [{"detail": "Not Found"}]}}
+
+
+class OkResponse(BaseModel):
+    ok: bool = Field(description="成功可否（true 固定）")
+
+    model_config = {"json_schema_extra": {"examples": [{"ok": True}]}}


### PR DESCRIPTION
目的:\n- 全 router の各エンドポイントに response_model と summary/description を付与し、OpenAPI の欠落を解消\n- 既存 schemas を参照するよう整理\n\n主な変更:\n- app/api/routers/healthz.py: response_model=OkResponse を追加。summary/description を整備\n- app/schemas/common.py: 共通の OkResponse スキーマを追加（例付き）\n- app/routers/gyms.py (v1): search/detail に summary/description を追加\n\n開発ツール:\n- Ruff format / check --fix を実行し、スタイルを統一\n\n影響範囲:\n- 既存 API のレスポンス構造は変更なし（healthz のみスキーマ定義を追加）\n\n確認項目:\n- /gyms/search, /gyms/{slug}, /equipments, /meta/*, /healthz の OpenAPI 定義が揃っていること\n- テストが通ること