### PR TITLE
feat: ジム画像の参照機能を追加

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -5,6 +5,7 @@ from .equipment import Equipment
 from .favorite import Favorite
 from .gym import Gym
 from .gym_equipment import GymEquipment
+from .gym_image import GymImage
 from .report import Report
 from .source import Source
 
@@ -16,4 +17,5 @@ __all__ = [
     "Source",
     "Report",
     "Favorite",
+    "GymImage",
 ]

--- a/app/models/gym_image.py
+++ b/app/models/gym_image.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class GymImage(Base):
+    __tablename__ = "gym_images"
+
+    id = Column(Integer, primary_key=True)
+    gym_id = Column(Integer, ForeignKey("gyms.id", ondelete="CASCADE"), nullable=False, index=True)
+    url = Column(String, nullable=False)
+    source = Column(String, nullable=True)
+    verified = Column(Boolean, nullable=False, server_default="false")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)

--- a/app/repositories/gym_image_repository.py
+++ b/app/repositories/gym_image_repository.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gym_image import GymImage
+
+
+class GymImageRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_by_gym_id(self, gym_id: int) -> list[GymImage]:
+        stmt = (
+            select(GymImage)
+            .where(GymImage.gym_id == gym_id)
+            .order_by(GymImage.created_at.desc(), GymImage.id.desc())
+        )
+        return (await self._session.scalars(stmt)).all()

--- a/app/schemas/gym_detail.py
+++ b/app/schemas/gym_detail.py
@@ -57,6 +57,15 @@ class GymDetailResponse(BaseModel):
         default_factory=list,
         description="設備ごとの在/無・検証状況などの詳細サマリ",
     )
+
+    # 追加: 参照用ジム画像（アップロードは不要、参照のみ）
+    class GymImage(BaseModel):
+        url: str = Field(description="画像URL")
+        source: str | None = Field(default=None, description="出典（任意）")
+        verified: bool = Field(default=False, description="検証済みか")
+        created_at: datetime | None = Field(default=None, description="登録日時")
+
+    images: list[GymImage] = Field(default_factory=list, description="関連画像の一覧")
     updated_at: str | None = Field(
         default=None, description="設備情報の最終更新（= last_verified_at の最大）"
     )
@@ -99,6 +108,14 @@ class GymDetailResponse(BaseModel):
                         }
                     ],
                     "updated_at": "2025-09-01T12:34:56Z",
+                    "images": [
+                        {
+                            "url": "https://example.com/image.jpg",
+                            "source": "instagram",
+                            "verified": False,
+                            "created_at": "2025-09-01T12:34:56Z",
+                        }
+                    ],
                 }
             ]
         }

--- a/migrations/versions/e1f2a3b4c5d6_add_gym_images_table.py
+++ b/migrations/versions/e1f2a3b4c5d6_add_gym_images_table.py
@@ -1,0 +1,40 @@
+"""add gym_images table
+
+Revision ID: e1f2a3b4c5d6
+Revises: d4e5f6a7b8c9
+Create Date: 2025-09-13 09:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e1f2a3b4c5d6"
+down_revision: str | None = "d4e5f6a7b8c9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "gym_images",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "gym_id", sa.Integer(), sa.ForeignKey("gyms.id", ondelete="CASCADE"), nullable=False
+        ),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column("verified", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_gym_images_gym_id", "gym_images", ["gym_id"])
+    op.create_index("ix_gym_images_created_at", "gym_images", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_gym_images_created_at", table_name="gym_images")
+    op.drop_index("ix_gym_images_gym_id", table_name="gym_images")
+    op.drop_table("gym_images")

--- a/tests/test_gym_images_detail.py
+++ b/tests/test_gym_images_detail.py
@@ -1,0 +1,41 @@
+import pytest
+from sqlalchemy import select
+
+from app.models import Gym
+from app.models.gym_image import GymImage
+
+
+@pytest.mark.anyio
+async def test_gym_detail_includes_images_field(app_client, session):
+    # Arrange: ensure target gym exists from seed
+    gym = await session.scalar(select(Gym).where(Gym.slug == "dummy-funabashi-east"))
+    assert gym is not None
+
+    # No images yet -> should return empty list
+    resp = await app_client.get(f"/gyms/{gym.slug}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "images" in body
+    assert isinstance(body["images"], list)
+    assert body["images"] == []
+
+    # Add two images
+    session.add_all(
+        [
+            GymImage(gym_id=gym.id, url="https://ex.com/1.jpg", source="web", verified=False),
+            GymImage(gym_id=gym.id, url="https://ex.com/2.jpg", source="web", verified=True),
+        ]
+    )
+    await session.commit()
+
+    # Act
+    resp2 = await app_client.get(f"/gyms/{gym.slug}")
+    assert resp2.status_code == 200
+    data = resp2.json()
+
+    # Assert
+    imgs = data.get("images")
+    assert isinstance(imgs, list) and len(imgs) == 2
+    # Ensure minimal fields
+    for it in imgs:
+        assert {"url", "source", "verified", "created_at"} <= set(it.keys())


### PR DESCRIPTION
## 変更内容\n- テーブル `gym_images` を追加（id, gym_id FK, url, source, verified=false, created_at）\n- GET `/gyms/{slug}` のレスポンスに `images: []` を追加\n- model/repository/service/schema（DTO）/テスト/Alembic migration を実装\n\n## 補足\n- 画像は参照のみ（アップロードは対象外）\n- 並び順は `created_at DESC, id DESC`。\n- スキーマは app/schemas/gym_detail.py に追加（images[].url/source/verified/created_at）。\n- Alembic: `e1f2a3b4c5d6_add_gym_images_table.py`\n