### PR TITLE
feat(frontend): お気に入り登録/一覧機能を追加

### DIFF
--- a/docs/frontend/favorites.md
+++ b/docs/frontend/favorites.md
@@ -1,0 +1,52 @@
+# Favorites Feature (Step 5)
+
+## Overview
+- Adds a toggleable "お気に入り" button to `/gyms/[slug]` that syncs with the backend API.
+- Provides a new `/me/favorites` page that lists registered gyms with quick access links and removal
+  controls.
+- Shares state between pages through the `useFavorites()` hook, enabling optimistic UI updates and a
+  single source of truth.
+
+## API Contract
+| Method | Endpoint | Notes |
+| ------ | -------- | ----- |
+| `GET` | `/me/favorites?device_id={id}` | Returns an array of favorites. Each item contains `gym_id`, `slug`, `name`, `pref`, `city`, `last_verified_at`, and may include `address`, `thumbnail_url`, `created_at`. |
+| `POST` | `/me/favorites` | Body: `{ "device_id": string, "gym_id": number }`. Idempotent. |
+| `DELETE` | `/me/favorites/{gym_id}?device_id={id}` | Removes the relation. Also idempotent. |
+
+- A pseudo user identifier (`device_id`) is generated client-side and persisted to
+  `localStorage (gid:favoritesDeviceId)` to satisfy the current anonymous workflow.
+- Error responses propagate via `ApiError` and surface through toast notifications and inline
+  messaging when relevant.
+
+## Frontend Architecture
+- `@/store/favorites` exposes `useFavorites()` which relies on `useSyncExternalStore` to share state
+  across components.
+  - Handles initial hydration (`listFavorites`), optimistic adds/removals, background refreshes, and
+    pending indicators per gym id.
+  - Persists/recovers the device identifier, falling back to deterministic generation when the
+    storage call fails (private browsing, etc.).
+- Services live in `@/services/favorites` and consolidate API interactions with response
+  normalisation to the `Favorite` domain model (`src/types/favorite.ts`).
+- Toast notifications (Shadcn + Radix) are wired through `Toaster` in `app/layout.tsx`, and the
+  toggle actions trigger success/error feedback without blocking user interaction.
+
+## UI Details
+- **Gym detail**: The button reflects current membership, disables while the mutation is pending, and
+  shows toast feedback for both add/remove flows.
+- **Favorites page (`/me/favorites`)**:
+  - Sorts entries by `createdAt` (newest first) when available, and displays a fallback message when
+    the timestamp is missing.
+  - Provides quick navigation to gym detail pages and removal controls with optimistic updates.
+  - Includes skeletons, empty/error states, and a manual refresh button (useful when testing the API
+    without reloading the route).
+
+## Known Limitations & Follow-ups
+- Authentication remains provisional; multiple browsers/devices cannot yet merge favorites for the
+  same user identity.
+- The backend schema currently omits richer metadata (ratings, equipment list, etc.) for favorites,
+  so cards display what is available and fall back gracefully when fields are `null`.
+- Toasts rely on client rendering; server-side rendering of routes that reference `useFavorites`
+  should continue to use the client boundary pattern adopted here.
+- Additional automated coverage for the `/me/favorites` page (e.g., optimistic removal snapshot
+  tests) can be added once the UI stabilises.

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,7 @@
 import type { Metadata } from "next";
+
+import { Toaster } from "@/components/ui/toaster";
+
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -11,6 +14,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="ja">
       <body className="min-h-screen bg-background font-sans text-foreground antialiased">
         {children}
+        <Toaster />
       </body>
     </html>
   );

--- a/frontend/app/me/favorites/page.tsx
+++ b/frontend/app/me/favorites/page.tsx
@@ -1,0 +1,5 @@
+import { FavoritesPage } from "@/features/favorites/FavoritesPage";
+
+export default function FavoritesRoute() {
+  return <FavoritesPage />;
+}

--- a/frontend/components/ui/toast.tsx
+++ b/frontend/components/ui/toast.tsx
@@ -1,0 +1,117 @@
+import type * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+import { forwardRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border border-border bg-background p-4 pr-6 text-sm shadow-lg transition-all",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive: "destructive group text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export const ToastProvider = ToastPrimitives.Provider;
+
+export const ToastViewport = forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed bottom-0 right-0 z-[100] flex max-h-screen w-full flex-col-reverse gap-2 p-4 sm:flex-col sm:p-6",
+      className,
+    )}
+    {...props}
+  />
+));
+
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+export const Toast = forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => (
+  <ToastPrimitives.Root
+    ref={ref}
+    className={cn(toastVariants({ variant }), className)}
+    {...props}
+  />
+));
+
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+export const ToastAction = forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-input bg-transparent px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
+
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+export const ToastClose = forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring group-hover:opacity-100",
+      className,
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+export const ToastTitle = forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold", className)}
+    {...props}
+  />
+));
+
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+export const ToastDescription = forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+export type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+export type ToastActionElement = React.ReactElement<typeof ToastAction>;

--- a/frontend/components/ui/toaster.tsx
+++ b/frontend/components/ui/toaster.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@/components/ui/toast";
+import { useToast } from "@/components/ui/use-toast";
+
+export function Toaster() {
+  const { toasts } = useToast();
+
+  return (
+    <ToastProvider>
+      {toasts.map(({ id, title, description, action, ...props }) => {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title ? <ToastTitle>{title}</ToastTitle> : null}
+              {description ? <ToastDescription>{description}</ToastDescription> : null}
+            </div>
+            {action ?? null}
+            <ToastClose />
+          </Toast>
+        );
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/frontend/components/ui/use-toast.ts
+++ b/frontend/components/ui/use-toast.ts
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import type { ReactElement, ReactNode } from "react";
+
+import type { ToastProps } from "@/components/ui/toast";
+
+const TOAST_LIMIT = 5;
+const TOAST_REMOVE_DELAY = 1000;
+
+type ToastActionElement = ReactElement<{ altText: string }>;
+
+type Toast = ToastProps & {
+  id: string;
+  title?: ReactNode;
+  description?: ReactNode;
+  action?: ToastActionElement;
+};
+
+type ToastState = {
+  toasts: Toast[];
+};
+
+const listeners: Array<(toast: ToastState) => void> = [];
+let memoryState: ToastState = { toasts: [] };
+
+const dispatch = (action: Action) => {
+  memoryState = reducer(memoryState, action);
+  listeners.forEach((listener) => listener(memoryState));
+};
+
+type Action =
+  | { type: "ADD_TOAST"; toast: Toast }
+  | { type: "DISMISS_TOAST"; toastId?: string }
+  | { type: "REMOVE_TOAST"; toastId?: string };
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return;
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId);
+    dispatch({ type: "REMOVE_TOAST", toastId });
+  }, TOAST_REMOVE_DELAY);
+
+  toastTimeouts.set(toastId, timeout);
+};
+
+function reducer(state: ToastState, action: Action): ToastState {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      };
+    case "DISMISS_TOAST": {
+      const { toastId } = action;
+
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id);
+        });
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((toast) =>
+          toast.id === action.toastId ? { ...toast, open: false } : toast,
+        ),
+      };
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return { ...state, toasts: [] };
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.filter((toast) => toast.id !== action.toastId),
+      };
+  }
+}
+
+export const toast = ({ ...props }: Omit<Toast, "id"> & { id?: string }) => {
+  const id = props.id ?? Math.random().toString(36).slice(2, 11);
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open: boolean) => {
+        if (!open) {
+          dispatch({ type: "DISMISS_TOAST", toastId: id });
+        }
+      },
+    },
+  });
+
+  return {
+    id,
+    dismiss: () => dispatch({ type: "DISMISS_TOAST", toastId: id }),
+    update: (updatedProps: ToastProps) =>
+      dispatch({ type: "ADD_TOAST", toast: { ...updatedProps, id } }),
+  };
+};
+
+export const useToast = () => {
+  const [state, setState] = useState<ToastState>(memoryState);
+
+  useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index >= 0) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, [setState]);
+
+  useEffect(() => {
+    memoryState = state;
+  }, [state]);
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  };
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.1.1",
+        "@radix-ui/react-toast": "^1.1.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.447.0",
@@ -548,7 +549,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1620,6 +1620,79 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1628,6 +1701,198 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+      "integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-escape-keydown": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
+      "integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -1649,6 +1914,157 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.1.5.tgz",
+      "integrity": "sha512-fRLn227WHIBRSzuRzGJ8W+5YALxofH23y0MlPLddaIpLpCDqdE0NZlS2NRQDRiptfxDeeCjgFIpexB1/zkxDlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
+      "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
+      "integrity": "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -2062,7 +2478,7 @@
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-toast": "^1.1.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.447.0",

--- a/frontend/src/features/favorites/FavoritesPage.tsx
+++ b/frontend/src/features/favorites/FavoritesPage.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "@/components/ui/use-toast";
+import { useFavorites } from "@/store/favorites";
+import type { Favorite } from "@/types/favorite";
+
+const formatRegion = (value?: string | null) => {
+  if (!value) {
+    return undefined;
+  }
+  return value
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+};
+
+const formatLocation = (prefecture?: string, city?: string) => {
+  const pref = formatRegion(prefecture);
+  const locality = formatRegion(city);
+  if (pref && locality) {
+    return `${pref} / ${locality}`;
+  }
+  if (pref) {
+    return pref;
+  }
+  if (locality) {
+    return locality;
+  }
+  return "エリア情報未設定";
+};
+
+const formatDate = (value?: string | null) => {
+  if (!value) {
+    return "登録日情報はまだありません";
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+const FavoritesSkeleton = () => (
+  <div className="flex min-h-screen flex-col gap-6 px-4 py-10">
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+      <div className="space-y-4">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Card key={index} className="overflow-hidden">
+            <Skeleton className="h-40 w-full" />
+            <CardContent className="space-y-3 pt-6">
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+              <div className="flex gap-2">
+                <Skeleton className="h-9 w-24" />
+                <Skeleton className="h-9 w-24" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+const FavoritesEmptyState = () => (
+  <Card className="border-dashed">
+    <CardHeader>
+      <CardTitle className="text-xl">お気に入りがまだありません</CardTitle>
+      <CardDescription>
+        気になるジムを見つけたら、詳細ページからお気に入り登録してみましょう。
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Button asChild type="button">
+        <Link href="/gyms">ジムを探しに行く</Link>
+      </Button>
+    </CardContent>
+  </Card>
+);
+
+const FavoritesErrorState = ({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) => (
+  <Card className="border-destructive/50 bg-destructive/5">
+    <CardHeader>
+      <CardTitle className="text-xl text-destructive">お気に入りを取得できませんでした</CardTitle>
+      <CardDescription className="text-destructive/90">{message}</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Button onClick={onRetry} type="button" variant="outline">
+        再試行する
+      </Button>
+    </CardContent>
+  </Card>
+);
+
+const FavoriteCard = ({
+  favorite,
+  onRemove,
+  isRemoving,
+}: {
+  favorite: Favorite;
+  onRemove: () => void;
+  isRemoving: boolean;
+}) => {
+  const { gym, createdAt } = favorite;
+  const locationLabel = formatLocation(gym.prefecture, gym.city);
+  const createdAtLabel = formatDate(createdAt);
+
+  return (
+    <Card className="overflow-hidden">
+      <div className="h-40 w-full bg-muted">
+        {gym.thumbnailUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            alt={`${gym.name} のサムネイル`}
+            className="h-full w-full object-cover"
+            src={gym.thumbnailUrl}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+            表示できる画像がまだありません。
+          </div>
+        )}
+      </div>
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-2xl">{gym.name}</CardTitle>
+        <CardDescription className="text-sm text-muted-foreground">{locationLabel}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {gym.address ? <p className="text-sm text-muted-foreground">{gym.address}</p> : null}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-xs text-muted-foreground">登録日: {createdAtLabel}</div>
+          <div className="flex gap-2">
+            <Button asChild size="sm" type="button">
+              <Link href={`/gyms/${gym.slug}`}>ジム詳細へ</Link>
+            </Button>
+            <Button
+              disabled={isRemoving}
+              onClick={onRemove}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              {isRemoving ? "更新中..." : "お気に入り解除"}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export function FavoritesPage() {
+  const { favorites, status, error, removeFavorite, isPending, refresh } = useFavorites();
+
+  const sortedFavorites = useMemo(() => {
+    return [...favorites].sort((a, b) => {
+      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bTime - aTime;
+    });
+  }, [favorites]);
+
+  const isLoading = status === "idle" || status === "loading";
+  const isSyncing = status === "syncing";
+
+  const handleRemove = useCallback(
+    async (gymId: number, gymName: string) => {
+      try {
+        await removeFavorite(gymId);
+        toast({
+          title: "お気に入りから削除しました",
+          description: `${gymName} をお気に入りから解除しました。`,
+        });
+      } catch (err) {
+        const message =
+          err instanceof Error && err.message
+            ? err.message
+            : "お気に入りの更新に失敗しました。もう一度お試しください。";
+        toast({
+          title: "お気に入りの更新に失敗しました",
+          description: message,
+          variant: "destructive",
+        });
+      }
+    },
+    [removeFavorite],
+  );
+
+  if (isLoading) {
+    return <FavoritesSkeleton />;
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col gap-6 px-4 py-10">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+        <header className="space-y-2">
+          <p className="text-sm uppercase tracking-wide text-muted-foreground">My Favorites</p>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">お気に入り一覧</h1>
+          <p className="text-sm text-muted-foreground">
+            詳細ページで登録したジムのお気に入りをここで管理できます。
+          </p>
+        </header>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          {error ? (
+            <p className="text-sm text-destructive">{error}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {isSyncing ? "最新の情報を取得しています..." : "お気に入りは自動的に同期されます。"}
+            </p>
+          )}
+          <Button
+            disabled={isSyncing}
+            onClick={() => {
+              void refresh();
+            }}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            再読み込み
+          </Button>
+        </div>
+
+        {error && sortedFavorites.length === 0 ? (
+          <FavoritesErrorState
+            message={error}
+            onRetry={() => {
+              void refresh();
+            }}
+          />
+        ) : null}
+
+        {sortedFavorites.length === 0 ? (
+          <FavoritesEmptyState />
+        ) : (
+          <div className="space-y-4">
+            {sortedFavorites.map((favorite) => (
+              <FavoriteCard
+                key={favorite.gym.id}
+                favorite={favorite}
+                isRemoving={isPending(favorite.gym.id)}
+                onRemove={() => {
+                  void handleRemove(favorite.gym.id, favorite.gym.name);
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/deviceId.ts
+++ b/frontend/src/lib/deviceId.ts
@@ -1,0 +1,74 @@
+const STORAGE_KEY = "gid:favoritesDeviceId";
+const DEVICE_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+
+let cachedDeviceId: string | null = null;
+
+const createDeviceId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID().replace(/-/g, "");
+  }
+
+  const randomPart = Math.random().toString(36).slice(2, 10);
+  const timestampPart = Date.now().toString(36);
+  return `gid${timestampPart}${randomPart}`;
+};
+
+export const getDeviceId = () => {
+  if (cachedDeviceId) {
+    return cachedDeviceId;
+  }
+
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && DEVICE_ID_PATTERN.test(stored)) {
+      cachedDeviceId = stored;
+      return cachedDeviceId;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+};
+
+export const ensureDeviceId = () => {
+  const existing = getDeviceId();
+  if (existing) {
+    return existing;
+  }
+
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const next = createDeviceId();
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, next);
+  } catch {
+    // Ignore write failures (e.g. private mode), still return the generated ID.
+  }
+
+  cachedDeviceId = next;
+  return next;
+};
+
+export const resetDeviceIdForTests = () => {
+  if (process.env.NODE_ENV === "production") {
+    return;
+  }
+
+  cachedDeviceId = null;
+
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Ignore storage errors in test environments.
+    }
+  }
+};

--- a/frontend/src/services/__tests__/favorites.test.ts
+++ b/frontend/src/services/__tests__/favorites.test.ts
@@ -1,0 +1,114 @@
+import { ApiError } from "@/lib/apiClient";
+import { addFavorite, listFavorites, removeFavorite } from "@/services/favorites";
+
+describe("favorites service", () => {
+  const originalEnv = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = "http://example.com";
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = originalEnv;
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+  });
+
+  it("fetches and normalises favorites", async () => {
+    const mockJson = jest.fn().mockResolvedValue([
+      {
+        gym_id: 10,
+        slug: "tokyo-gym",
+        name: "Tokyo Gym",
+        pref: "tokyo",
+        city: "shibuya",
+        address: "東京都渋谷区1-2-3",
+        thumbnail_url: "https://example.com/thumb.jpg",
+        last_verified_at: "2024-09-01T12:00:00Z",
+        created_at: "2024-09-10T09:30:00Z",
+      },
+    ]);
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: mockJson,
+    } as unknown as Response);
+
+    const result = await listFavorites("device-123");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://example.com/me/favorites?device_id=device-123",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+
+    expect(result).toEqual([
+      {
+        createdAt: "2024-09-10T09:30:00Z",
+        gym: {
+          id: 10,
+          slug: "tokyo-gym",
+          name: "Tokyo Gym",
+          prefecture: "tokyo",
+          city: "shibuya",
+          address: "東京都渋谷区1-2-3",
+          thumbnailUrl: "https://example.com/thumb.jpg",
+          lastVerifiedAt: "2024-09-01T12:00:00Z",
+        },
+      },
+    ]);
+  });
+
+  it("throws an ApiError when listFavorites fails", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      text: jest.fn().mockResolvedValue("Internal error"),
+    } as unknown as Response);
+
+    await expect(listFavorites("device-123")).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("sends a POST request to add a favorite", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: jest.fn(),
+    } as unknown as Response);
+
+    await addFavorite(42, "device-xyz");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://example.com/me/favorites",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ device_id: "device-xyz", gym_id: 42 }),
+      }),
+    );
+  });
+
+  it("sends a DELETE request to remove a favorite", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: jest.fn(),
+    } as unknown as Response);
+
+    await removeFavorite(42, "device-xyz");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://example.com/me/favorites/42?device_id=device-xyz",
+      expect.objectContaining({
+        method: "DELETE",
+      }),
+    );
+  });
+});

--- a/frontend/src/services/favorites.ts
+++ b/frontend/src/services/favorites.ts
@@ -1,16 +1,69 @@
 import { apiRequest } from "@/lib/apiClient";
+import type { Favorite } from "@/types/favorite";
 
-export async function addFavorite(gymId: number, options: { signal?: AbortSignal } = {}) {
-  await apiRequest(`/me/favorites/${gymId}`, {
+interface RawFavoriteItem {
+  gym_id: number;
+  slug: string;
+  name: string;
+  pref?: string | null;
+  city?: string | null;
+  address?: string | null;
+  thumbnail_url?: string | null;
+  thumbnailUrl?: string | null;
+  last_verified_at?: string | null;
+  created_at?: string | null;
+}
+
+const normalizeFavorite = (input: RawFavoriteItem): Favorite => ({
+  createdAt: input.created_at ?? null,
+  gym: {
+    id: input.gym_id,
+    slug: input.slug,
+    name: input.name,
+    prefecture: input.pref ?? "",
+    city: input.city ?? "",
+    address: input.address ?? undefined,
+    thumbnailUrl: input.thumbnailUrl ?? input.thumbnail_url ?? null,
+    lastVerifiedAt: input.last_verified_at ?? null,
+  },
+});
+
+export async function listFavorites(
+  deviceId: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<Favorite[]> {
+  const response = await apiRequest<RawFavoriteItem[]>("/me/favorites", {
+    method: "GET",
+    query: { device_id: deviceId },
+    signal: options.signal,
+  });
+
+  return response.map(normalizeFavorite);
+}
+
+export async function addFavorite(
+  gymId: number,
+  deviceId: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<void> {
+  await apiRequest("/me/favorites", {
     method: "POST",
-    body: JSON.stringify({}),
+    body: JSON.stringify({
+      device_id: deviceId,
+      gym_id: gymId,
+    }),
     signal: options.signal,
   });
 }
 
-export async function removeFavorite(gymId: number, options: { signal?: AbortSignal } = {}) {
+export async function removeFavorite(
+  gymId: number,
+  deviceId: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<void> {
   await apiRequest(`/me/favorites/${gymId}`, {
     method: "DELETE",
+    query: { device_id: deviceId },
     signal: options.signal,
   });
 }

--- a/frontend/src/store/favorites.ts
+++ b/frontend/src/store/favorites.ts
@@ -1,88 +1,79 @@
 "use client";
 
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo } from "react";
+import { useSyncExternalStore } from "react";
 
-type FavoriteStoreState = {
-  ids: Set<number>;
+import { ensureDeviceId, resetDeviceIdForTests } from "@/lib/deviceId";
+import { addFavorite, listFavorites, removeFavorite } from "@/services/favorites";
+import type { Favorite } from "@/types/favorite";
+import type { GymDetail, GymSummary } from "@/types/gym";
+
+type FavoritesStatus = "idle" | "loading" | "ready" | "syncing" | "error";
+
+type FavoritesState = {
+  favorites: Favorite[];
+  pending: Set<number>;
+  status: FavoritesStatus;
+  error: string | null;
+  isHydrated: boolean;
+};
+
+type FavoritesSnapshot = {
+  favorites: Favorite[];
+  favoriteIds: number[];
+  pendingIds: number[];
+  status: FavoritesStatus;
+  error: string | null;
   isInitialized: boolean;
 };
 
-const STORAGE_KEY = "favoriteGymIds";
+type FavoriteCandidate = GymSummary | GymDetail;
 
-let state: FavoriteStoreState = {
-  ids: new Set<number>(),
-  isInitialized: false,
+const DEFAULT_LOAD_ERROR = "お気に入り一覧の取得に失敗しました。";
+const DEFAULT_MUTATION_ERROR = "お気に入りの更新に失敗しました。";
+
+let state: FavoritesState = {
+  favorites: [],
+  pending: new Set<number>(),
+  status: "idle",
+  error: null,
+  isHydrated: false,
 };
 
-let snapshotCache = {
-  favoriteGymIds: [] as number[],
+let snapshotCache: FavoritesSnapshot = {
+  favorites: [],
+  favoriteIds: [],
+  pendingIds: [],
+  status: "idle",
+  error: null,
   isInitialized: false,
 };
 
 const listeners = new Set<() => void>();
+let inflightLoad: Promise<void> | null = null;
+
+const cloneFavorite = (input: Favorite): Favorite => ({
+  createdAt: input.createdAt,
+  gym: { ...input.gym },
+});
+
+const buildSnapshot = (current: FavoritesState): FavoritesSnapshot => ({
+  favorites: current.favorites.map(cloneFavorite),
+  favoriteIds: current.favorites.map((favorite) => favorite.gym.id),
+  pendingIds: Array.from(current.pending),
+  status: current.status,
+  error: current.error,
+  isInitialized: current.isHydrated,
+});
 
 const notify = () => {
   listeners.forEach((listener) => listener());
 };
 
-const persist = (ids: Set<number>) => {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  try {
-    const serialised = JSON.stringify(Array.from(ids));
-    window.localStorage.setItem(STORAGE_KEY, serialised);
-  } catch {
-    // ignore write failures so the UI remains responsive even in private mode.
-  }
-};
-
-const setState = (next: FavoriteStoreState, opts: { persist?: boolean; notify?: boolean } = {}) => {
-  state = next;
-  snapshotCache = {
-    favoriteGymIds: Array.from(state.ids),
-    isInitialized: state.isInitialized,
-  };
-  if (opts.persist) {
-    persist(state.ids);
-  }
-  if (opts.notify !== false) {
-    notify();
-  }
-};
-
-const initialiseFromStorage = () => {
-  if (state.isInitialized || typeof window === "undefined") {
-    return;
-  }
-
-  let ids: number[] = [];
-
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) {
-        ids = parsed
-          .map((value) => {
-            const asNumber = typeof value === "string" ? Number.parseInt(value, 10) : Number(value);
-            return Number.isFinite(asNumber) ? asNumber : undefined;
-          })
-          .filter((value): value is number => typeof value === "number");
-      }
-    }
-  } catch {
-    ids = [];
-  }
-
-  setState(
-    {
-      ids: new Set(ids),
-      isInitialized: true,
-    },
-    { notify: true },
-  );
+const setState = (updater: (prev: FavoritesState) => FavoritesState) => {
+  state = updater(state);
+  snapshotCache = buildSnapshot(state);
+  notify();
 };
 
 const subscribe = (listener: () => void) => {
@@ -92,74 +83,230 @@ const subscribe = (listener: () => void) => {
   };
 };
 
-const getSnapshot = () => {
-  if (typeof window !== "undefined") {
-    initialiseFromStorage();
-  }
+const getSnapshot = () => snapshotCache;
+const getServerSnapshot = () => snapshotCache;
 
-  return snapshotCache;
-};
+const toFavoriteSummary = (gym: FavoriteCandidate): GymSummary => ({
+  id: gym.id,
+  slug: gym.slug,
+  name: gym.name,
+  prefecture: gym.prefecture,
+  city: gym.city,
+  address: gym.address,
+  thumbnailUrl: gym.thumbnailUrl ?? null,
+  equipments: "equipments" in gym ? gym.equipments : undefined,
+  lastVerifiedAt: "lastVerifiedAt" in gym ? gym.lastVerifiedAt ?? null : undefined,
+});
 
-const getServerSnapshot = () => ({ favoriteGymIds: [] as number[], isInitialized: false });
-
-const addFavoriteIdInternal = (gymId: number) => {
-  initialiseFromStorage();
-  if (state.ids.has(gymId)) {
+const loadFavorites = async (deviceId: string, { force = false } = {}) => {
+  if (!deviceId) {
     return;
   }
 
-  const nextIds = new Set(state.ids);
-  nextIds.add(gymId);
+  if (inflightLoad && !force) {
+    return inflightLoad;
+  }
 
-  setState(
-    {
-      ids: nextIds,
-      isInitialized: true,
-    },
-    { persist: true },
-  );
-};
-
-const removeFavoriteIdInternal = (gymId: number) => {
-  initialiseFromStorage();
-  if (!state.ids.has(gymId)) {
+  if (state.isHydrated && state.status === "ready" && !force) {
     return;
   }
 
-  const nextIds = new Set(state.ids);
-  nextIds.delete(gymId);
+  setState((prev) => ({
+    favorites: prev.favorites,
+    pending: new Set(prev.pending),
+    status: prev.isHydrated ? "syncing" : "loading",
+    error: null,
+    isHydrated: prev.isHydrated,
+  }));
 
-  setState(
-    {
-      ids: nextIds,
-      isInitialized: true,
-    },
-    { persist: true },
-  );
+  inflightLoad = listFavorites(deviceId)
+    .then((favorites) => {
+      setState((prev) => ({
+        favorites,
+        pending: new Set(prev.pending),
+        status: "ready",
+        error: null,
+        isHydrated: true,
+      }));
+    })
+    .catch((error) => {
+      const message = error instanceof Error && error.message ? error.message : DEFAULT_LOAD_ERROR;
+      setState((prev) => ({
+        favorites: prev.favorites,
+        pending: new Set(prev.pending),
+        status: prev.isHydrated ? prev.status : "error",
+        error: message,
+        isHydrated: true,
+      }));
+      throw error;
+    })
+    .finally(() => {
+      inflightLoad = null;
+    });
+
+  return inflightLoad;
 };
 
-export function useFavoriteGyms() {
+const addFavoriteInternal = async (candidate: FavoriteCandidate) => {
+  const deviceId = ensureDeviceId();
+  if (!deviceId) {
+    throw new Error("デバイスIDの初期化に失敗しました。");
+  }
+
+  const summary = toFavoriteSummary(candidate);
+  const optimistic: Favorite = {
+    gym: summary,
+    createdAt: new Date().toISOString(),
+  };
+
+  const previousFavorites = state.favorites.map(cloneFavorite);
+  const previousPending = new Set(state.pending);
+
+  setState((prev) => {
+    const nextFavorites = prev.favorites.filter((item) => item.gym.id !== summary.id);
+    nextFavorites.unshift(optimistic);
+    const nextPending = new Set(prev.pending);
+    nextPending.add(summary.id);
+
+    return {
+      favorites: nextFavorites,
+      pending: nextPending,
+      status: prev.status === "idle" ? "ready" : prev.status,
+      error: null,
+      isHydrated: true,
+    };
+  });
+
+  try {
+    await addFavorite(summary.id, deviceId);
+    setState((prev) => ({
+      favorites: prev.favorites,
+      pending: (() => {
+        const next = new Set(prev.pending);
+        next.delete(summary.id);
+        return next;
+      })(),
+      status: prev.status,
+      error: prev.error,
+      isHydrated: prev.isHydrated,
+    }));
+    await loadFavorites(deviceId, { force: true });
+  } catch (error) {
+    setState(() => ({
+      favorites: previousFavorites.map(cloneFavorite),
+      pending: new Set(previousPending),
+      status: "ready",
+      error: error instanceof Error && error.message ? error.message : DEFAULT_MUTATION_ERROR,
+      isHydrated: true,
+    }));
+    throw error;
+  }
+};
+
+const removeFavoriteInternal = async (gymId: number) => {
+  const deviceId = ensureDeviceId();
+  if (!deviceId) {
+    throw new Error("デバイスIDの初期化に失敗しました。");
+  }
+
+  const previousFavorites = state.favorites.map(cloneFavorite);
+  const previousPending = new Set(state.pending);
+
+  setState((prev) => {
+    const nextFavorites = prev.favorites.filter((item) => item.gym.id !== gymId);
+    const nextPending = new Set(prev.pending);
+    nextPending.add(gymId);
+
+    return {
+      favorites: nextFavorites,
+      pending: nextPending,
+      status: prev.status === "idle" ? "ready" : prev.status,
+      error: null,
+      isHydrated: true,
+    };
+  });
+
+  try {
+    await removeFavorite(gymId, deviceId);
+    setState((prev) => ({
+      favorites: prev.favorites,
+      pending: (() => {
+        const next = new Set(prev.pending);
+        next.delete(gymId);
+        return next;
+      })(),
+      status: prev.status,
+      error: prev.error,
+      isHydrated: prev.isHydrated,
+    }));
+    await loadFavorites(deviceId, { force: true });
+  } catch (error) {
+    setState(() => ({
+      favorites: previousFavorites.map(cloneFavorite),
+      pending: new Set(previousPending),
+      status: "ready",
+      error: error instanceof Error && error.message ? error.message : DEFAULT_MUTATION_ERROR,
+      isHydrated: true,
+    }));
+    throw error;
+  }
+};
+
+export function useFavorites() {
   const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
-  const addFavoriteId = useCallback((gymId: number) => {
-    addFavoriteIdInternal(gymId);
-  }, []);
+  useEffect(() => {
+    if (!snapshot.isInitialized) {
+      const deviceId = ensureDeviceId();
+      if (deviceId) {
+        void loadFavorites(deviceId);
+      }
+    }
+  }, [snapshot.isInitialized]);
 
-  const removeFavoriteId = useCallback((gymId: number) => {
-    removeFavoriteIdInternal(gymId);
-  }, []);
+  const pendingSet = useMemo(() => new Set(snapshot.pendingIds), [snapshot.pendingIds]);
 
   const isFavorite = useCallback(
-    (gymId: number) => snapshot.favoriteGymIds.includes(gymId),
-    [snapshot.favoriteGymIds],
+    (gymId: number) => snapshot.favoriteIds.includes(gymId),
+    [snapshot.favoriteIds],
   );
 
+  const isPending = useCallback((gymId: number) => pendingSet.has(gymId), [pendingSet]);
+
+  const add = useCallback((candidate: FavoriteCandidate) => addFavoriteInternal(candidate), []);
+
+  const remove = useCallback((gymId: number) => removeFavoriteInternal(gymId), []);
+
+  const toggle = useCallback(
+    (candidate: FavoriteCandidate) => {
+      if (isFavorite(candidate.id)) {
+        return remove(candidate.id);
+      }
+      return add(candidate);
+    },
+    [add, remove, isFavorite],
+  );
+
+  const refresh = useCallback(() => {
+    const deviceId = ensureDeviceId();
+    if (!deviceId) {
+      return Promise.resolve();
+    }
+    return loadFavorites(deviceId, { force: true }) ?? Promise.resolve();
+  }, []);
+
   return {
-    favoriteGymIds: snapshot.favoriteGymIds,
+    favorites: snapshot.favorites,
+    favoriteIds: snapshot.favoriteIds,
+    status: snapshot.status,
+    error: snapshot.error,
     isInitialized: snapshot.isInitialized,
-    addFavoriteId,
-    removeFavoriteId,
     isFavorite,
+    isPending,
+    addFavorite: add,
+    removeFavorite: remove,
+    toggleFavorite: toggle,
+    refresh,
   };
 }
 
@@ -169,14 +316,14 @@ export function resetFavoriteStoreForTests() {
   }
 
   state = {
-    ids: new Set<number>(),
-    isInitialized: false,
+    favorites: [],
+    pending: new Set<number>(),
+    status: "idle",
+    error: null,
+    isHydrated: false,
   };
-
-  snapshotCache = {
-    favoriteGymIds: [],
-    isInitialized: false,
-  };
-
+  snapshotCache = buildSnapshot(state);
+  inflightLoad = null;
+  resetDeviceIdForTests();
   notify();
 }

--- a/frontend/src/types/favorite.ts
+++ b/frontend/src/types/favorite.ts
@@ -1,0 +1,6 @@
+import type { GymSummary } from "@/types/gym";
+
+export interface Favorite {
+  gym: GymSummary;
+  createdAt: string | null;
+}


### PR DESCRIPTION
## 概要
- ジム詳細ページからお気に入り登録/解除できるようにする
- お気に入り一覧ページ（/me/favorites）を用意し、状態を共有しながら表示する
- API レスポンスを正規化し、トースト通知で成功/失敗を明示する

## 変更点
- useFavorites フックを実装し、デバイス ID 生成・API 呼び出し・楽観的更新を一元化
- ジム詳細ページのトグル処理を useFavorites/トースト通知に差し替え
- お気に入り一覧ページの UI／状態遷移（ローディング、空、エラー、再読込）を追加
- Radix Toast を利用したトースト実装を追加し、レイアウトに Toaster を組み込み
- favorites サービス・型定義・deviceId ユーティリティを追加
- favorites サービスとジム詳細ページのトグル挙動を Jest で検証
- docs/frontend/favorites.md に API/状態同期/既知の制限を記載

## 動作確認
1. `cd frontend`
2. `npm run test`

## その他
- スクリーンキャプチャ（ジム詳細で登録 → /me/favorites に反映）を GIF で添付してください。
