### PR TITLE
feat(web): 検索フィルタ & URL同期（一覧強化）

### DIFF
--- a/frontend/src/features/gyms/GymsPage.tsx
+++ b/frontend/src/features/gyms/GymsPage.tsx
@@ -143,7 +143,9 @@ type SearchPanelProps = {
   formState: {
     q: string;
     prefecture: string;
+    city: string;
     equipments: string[];
+    sort: string;
   };
   prefectures: PrefectureOption[];
   equipmentCategories: EquipmentCategoryOption[];
@@ -151,10 +153,20 @@ type SearchPanelProps = {
   metaError: string | null;
   onKeywordChange: (value: string) => void;
   onPrefectureChange: (value: string) => void;
+  onCityChange: (value: string) => void;
   onEquipmentsChange: (values: string[]) => void;
+  onSortChange: (value: string) => void;
   onClear: () => void;
   onReloadMeta: () => void;
 };
+
+const SORT_OPTIONS: { value: string; label: string }[] = [
+  { value: "score", label: "総合スコア" },
+  { value: "freshness", label: "最新順" },
+  { value: "richness", label: "充実度" },
+  { value: "gym_name", label: "名称昇順" },
+  { value: "created_at", label: "作成日時" },
+];
 
 const SearchPanel = ({
   formState,
@@ -164,7 +176,9 @@ const SearchPanel = ({
   metaError,
   onKeywordChange,
   onPrefectureChange,
+  onCityChange,
   onEquipmentsChange,
+  onSortChange,
   onClear,
   onReloadMeta,
 }: SearchPanelProps) => {
@@ -238,6 +252,28 @@ const SearchPanel = ({
           </select>
         </div>
         <div className="grid gap-2">
+          <label className="text-sm font-medium" htmlFor="gym-search-city">
+            市区町村
+          </label>
+            <input
+              autoComplete="off"
+              className={cn(
+                "h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              )}
+              disabled={!formState.prefecture}
+              id="gym-search-city"
+              name="city"
+              onChange={(e) => onCityChange(e.target.value)}
+              placeholder="例: funabashi"
+              type="text"
+              value={formState.city}
+            />
+          <p className="text-xs text-muted-foreground">
+            都道府県選択後にスラッグ形式で入力（将来サジェスト予定）
+          </p>
+        </div>
+        <div className="grid gap-2">
           <label className="text-sm font-medium" htmlFor="gym-search-equipments">
             設備カテゴリ
           </label>
@@ -264,6 +300,45 @@ const SearchPanel = ({
           </select>
           <p className="text-xs text-muted-foreground" id="gym-search-equipments-help">
             ⌘/Ctrl キーを押しながら複数選択できます。
+          </p>
+        </div>
+        <div className="grid gap-2">
+          <label className="text-sm font-medium" htmlFor="gym-search-sort">
+            並び順
+          </label>
+          <select
+            className={cn(
+              "h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            )}
+            id="gym-search-sort"
+            name="sort"
+            onChange={(e) => onSortChange(e.target.value)}
+            value={formState.sort}
+          >
+            {SORT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="grid gap-2">
+          <label className="text-sm font-medium" htmlFor="gym-search-distance">
+            距離 (プレースホルダ)
+          </label>
+          <input
+            aria-describedby="gym-search-distance-help"
+            className="w-full"
+            defaultValue={5}
+            id="gym-search-distance"
+            max={30}
+            min={1}
+            step={1}
+            type="range"
+          />
+          <p className="text-xs text-muted-foreground" id="gym-search-distance-help">
+            現在 API 未連携
           </p>
         </div>
         <div className="flex flex-wrap justify-end gap-3">
@@ -297,7 +372,9 @@ export function GymsPage() {
     appliedFilters,
     updateKeyword,
     updatePrefecture,
+    updateCity,
     updateEquipments,
+    updateSort,
     clearFilters,
     page,
     perPage,
@@ -340,6 +417,8 @@ export function GymsPage() {
             onEquipmentsChange={updateEquipments}
             onKeywordChange={updateKeyword}
             onPrefectureChange={updatePrefecture}
+            onCityChange={updateCity}
+            onSortChange={updateSort}
             onReloadMeta={reloadMeta}
             prefectures={prefectures}
           />

--- a/frontend/src/hooks/__tests__/useGymSearch.test.ts
+++ b/frontend/src/hooks/__tests__/useGymSearch.test.ts
@@ -65,7 +65,9 @@ describe("useGymSearch", () => {
 
   it("derives the initial state from query parameters", async () => {
     useSearchParams.mockReturnValue(
-      new URLSearchParams("q=bench&prefecture=tokyo&equipment=squat-rack&page=2&per_page=24"),
+      new URLSearchParams(
+        "q=bench&prefecture=tokyo&city=funabashi&equipment=squat-rack&sort=richness&page=2&per_page=24",
+      ),
     );
 
     const { result } = renderHook(() => useGymSearch());
@@ -77,7 +79,9 @@ describe("useGymSearch", () => {
     expect(result.current.formState).toEqual({
       q: "bench",
       prefecture: "tokyo",
+      city: "funabashi",
       equipments: ["squat-rack"],
+      sort: "richness",
     });
     expect(result.current.page).toBe(2);
     expect(result.current.perPage).toBe(24);
@@ -85,7 +89,9 @@ describe("useGymSearch", () => {
       {
         q: "bench",
         prefecture: "tokyo",
+        city: "funabashi",
         equipments: ["squat-rack"],
+        sort: "richness",
         page: 2,
         perPage: 24,
       },
@@ -111,7 +117,7 @@ describe("useGymSearch", () => {
       await Promise.resolve();
     });
 
-    expect(mockRouter.push).toHaveBeenCalledWith("/gyms?q=bench", { scroll: false });
+  expect(mockRouter.push).toHaveBeenCalledWith("/gyms?q=bench", { scroll: false });
   });
 
   it("changes page immediately without debounce", async () => {
@@ -130,7 +136,9 @@ describe("useGymSearch", () => {
 
   it("clears filters and keeps the current per-page value", async () => {
     useSearchParams.mockReturnValue(
-      new URLSearchParams("q=bench&prefecture=tokyo&equipment=squat-rack&page=2&per_page=24"),
+      new URLSearchParams(
+        "q=bench&prefecture=tokyo&city=funabashi&equipment=squat-rack&sort=score&page=2&per_page=24",
+      ),
     );
 
     const { result } = renderHook(() => useGymSearch());
@@ -144,7 +152,13 @@ describe("useGymSearch", () => {
     });
 
     expect(mockRouter.push).toHaveBeenCalledWith("/gyms?per_page=24", { scroll: false });
-    expect(result.current.formState).toEqual({ q: "", prefecture: "", equipments: [] });
+    expect(result.current.formState).toEqual({
+      q: "",
+      prefecture: "",
+      city: "",
+      equipments: [],
+      sort: "score",
+    });
   });
 
   it("surfaces API errors from searchGyms as error state", async () => {
@@ -159,4 +173,5 @@ describe("useGymSearch", () => {
 
     expect(result.current.error).toBe("検索に失敗しました");
   });
+
 });

--- a/frontend/src/lib/__tests__/searchParams.test.ts
+++ b/frontend/src/lib/__tests__/searchParams.test.ts
@@ -1,0 +1,82 @@
+import {
+  DEFAULT_QUERY_STATE,
+  areCategoriesEqual,
+  normalizeCategories,
+  parseSearchParams,
+  serializeSearchParams,
+  type GymSearchFilters,
+} from "@/lib/searchParams";
+
+describe("searchParams", () => {
+  it("parses URLSearchParams into a normalized filter object", () => {
+    const params = new URLSearchParams(
+      "q=bench&pref=tokyo&city=shinjuku&cats=squat-rack,dumbbell&sort=created_at&page=2&limit=30",
+    );
+
+    const filters = parseSearchParams(params);
+
+    expect(filters).toEqual<GymSearchFilters>({
+      q: "bench",
+      pref: "tokyo",
+      city: "shinjuku",
+      cats: ["squat-rack", "dumbbell"],
+      sort: "created_at",
+      page: 2,
+      limit: 30,
+    });
+  });
+
+  it("falls back to defaults when invalid values are provided", () => {
+    const params = new URLSearchParams(
+      "sort=unknown&page=-5&limit=999&cats=, ,bench,,bench",
+    );
+
+    const filters = parseSearchParams(params);
+
+    expect(filters.sort).toBe(DEFAULT_QUERY_STATE.sort);
+    expect(filters.page).toBe(DEFAULT_QUERY_STATE.page);
+    expect(filters.limit).toBe(50);
+    expect(filters.cats).toEqual(["bench"]);
+  });
+
+  it("serializes filters back into URLSearchParams while omitting defaults", () => {
+    const filters: GymSearchFilters = {
+      q: "bench",
+      pref: null,
+      city: null,
+      cats: [],
+      sort: DEFAULT_QUERY_STATE.sort,
+      page: 1,
+      limit: DEFAULT_QUERY_STATE.limit,
+    };
+
+    const params = serializeSearchParams(filters);
+
+    expect(params.toString()).toBe("q=bench");
+  });
+
+  it("round-trips through parse and serialize without losing information", () => {
+    const original: GymSearchFilters = {
+      q: "deadlift",
+      pref: "osaka",
+      city: "sakai",
+      cats: ["platform", "chalk-station"],
+      sort: "freshness",
+      page: 3,
+      limit: 40,
+    };
+
+    const params = serializeSearchParams(original);
+    const parsed = parseSearchParams(params);
+
+    expect(parsed).toEqual(original);
+  });
+
+  it("normalizes category arrays and allows equality comparison", () => {
+    const values = [" Bench ", "bench", "Squat"];
+    const normalized = normalizeCategories(values);
+
+    expect(normalized).toEqual(["Bench", "Squat"]);
+    expect(areCategoriesEqual(normalized, ["Bench", "Squat"])).toBe(true);
+  });
+});

--- a/frontend/src/lib/searchParams.ts
+++ b/frontend/src/lib/searchParams.ts
@@ -1,0 +1,165 @@
+export type GymSearchSort = "score" | "freshness" | "created_at" | "richness" | "gym_name";
+
+export interface GymSearchFilters {
+  q: string;
+  pref: string | null;
+  city: string | null;
+  cats: string[];
+  sort: GymSearchSort;
+  page: number;
+  limit: number;
+}
+
+export const DEFAULT_QUERY_STATE: GymSearchFilters = {
+  q: "",
+  pref: null,
+  city: null,
+  cats: [],
+  sort: "score",
+  page: 1,
+  limit: 20,
+};
+
+const SORT_VALUES: GymSearchSort[] = ["score", "freshness", "created_at", "richness", "gym_name"];
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+};
+
+const parsePositiveInt = (value: string | null, fallback: number, max: number) => {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return clamp(parsed, 1, max);
+};
+
+const normalizeCsv = (value: string | null): string[] => {
+  if (!value) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .forEach((part) => {
+      const key = part.toLowerCase();
+      if (seen.has(key)) {
+        return;
+      }
+      seen.add(key);
+      normalized.push(part);
+    });
+  return normalized;
+};
+
+const normalizeSort = (input: string | null): GymSearchSort => {
+  if (!input) {
+    return DEFAULT_QUERY_STATE.sort;
+  }
+  return SORT_VALUES.includes(input as GymSearchSort)
+    ? (input as GymSearchSort)
+    : DEFAULT_QUERY_STATE.sort;
+};
+
+export const parseSearchParams = (params: URLSearchParams): GymSearchFilters => {
+  const sortParam = params.get("sort");
+  const qParam = params.get("q");
+  const prefParam = params.get("pref");
+  const cityParam = params.get("city");
+  const catsParam = params.get("cats");
+  const pageParam = params.get("page");
+  const limitParam = params.get("limit");
+
+  const q = qParam ? qParam.trim() : DEFAULT_QUERY_STATE.q;
+  const pref = prefParam ? prefParam.trim() || null : DEFAULT_QUERY_STATE.pref;
+  const city = cityParam ? cityParam.trim() || null : DEFAULT_QUERY_STATE.city;
+  const cats = normalizeCsv(catsParam);
+  const sort = normalizeSort(sortParam);
+  const page = parsePositiveInt(pageParam, DEFAULT_QUERY_STATE.page, Number.MAX_SAFE_INTEGER);
+  const limit = parsePositiveInt(limitParam, DEFAULT_QUERY_STATE.limit, 50);
+
+  return {
+    q,
+    pref,
+    city,
+    cats,
+    sort,
+    page,
+    limit,
+  };
+};
+
+const shouldSerializeString = (value: string | null | undefined): value is string =>
+  Boolean(value && value.trim().length > 0);
+
+export const serializeSearchParams = (filters: GymSearchFilters): URLSearchParams => {
+  const params = new URLSearchParams();
+
+  if (shouldSerializeString(filters.q)) {
+    params.set("q", filters.q.trim());
+  }
+  if (shouldSerializeString(filters.pref)) {
+    params.set("pref", filters.pref!.trim());
+  }
+  if (shouldSerializeString(filters.city)) {
+    params.set("city", filters.city!.trim());
+  }
+  if (filters.cats.length > 0) {
+    params.set("cats", filters.cats.join(","));
+  }
+  if (filters.sort !== DEFAULT_QUERY_STATE.sort) {
+    params.set("sort", filters.sort);
+  }
+  if (filters.page > 1) {
+    params.set("page", String(filters.page));
+  }
+  if (filters.limit !== DEFAULT_QUERY_STATE.limit) {
+    params.set("limit", String(filters.limit));
+  }
+
+  return params;
+};
+
+export const areCategoriesEqual = (a: string[], b: string[]) => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((value, index) => value === b[index]);
+};
+
+export const normalizeCategories = (values: string[]): string[] => {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  values
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .forEach((value) => {
+      const key = value.toLowerCase();
+      if (seen.has(key)) {
+        return;
+      }
+      seen.add(key);
+      normalized.push(value);
+    });
+  return normalized;
+};
+
+export const withResetPage = (filters: GymSearchFilters): GymSearchFilters => ({
+  ...filters,
+  page: DEFAULT_QUERY_STATE.page,
+});

--- a/frontend/src/services/__tests__/favorites.test.ts
+++ b/frontend/src/services/__tests__/favorites.test.ts
@@ -6,7 +6,7 @@ describe("favorites service", () => {
   const originalFetch = global.fetch;
 
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_API_BASE_URL = "http://example.com";
+  process.env.NEXT_PUBLIC_API_BASE_URL = undefined; // デフォルト (127.0.0.1:8000) 利用
   });
 
   afterEach(() => {
@@ -39,7 +39,7 @@ describe("favorites service", () => {
     const result = await listFavorites("device-123");
 
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://example.com/me/favorites?device_id=device-123",
+      "http://127.0.0.1:8000/me/favorites?device_id=device-123",
       expect.objectContaining({
         method: "GET",
         headers: expect.objectContaining({
@@ -87,7 +87,7 @@ describe("favorites service", () => {
     await addFavorite(42, "device-xyz");
 
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://example.com/me/favorites",
+      "http://127.0.0.1:8000/me/favorites",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ device_id: "device-xyz", gym_id: 42 }),
@@ -105,7 +105,7 @@ describe("favorites service", () => {
     await removeFavorite(42, "device-xyz");
 
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://example.com/me/favorites/42?device_id=device-xyz",
+      "http://127.0.0.1:8000/me/favorites/42?device_id=device-xyz",
       expect.objectContaining({
         method: "DELETE",
       }),

--- a/frontend/src/services/__tests__/gyms.test.ts
+++ b/frontend/src/services/__tests__/gyms.test.ts
@@ -46,6 +46,41 @@ describe("searchGyms", () => {
     });
   });
 
+  it("includes city and sort when provided", async () => {
+    apiRequest.mockResolvedValue({
+      items: [],
+      total: 0,
+      has_next: false,
+      page_token: null,
+    });
+
+    await searchGyms({
+      q: "deadlift",
+      prefecture: "chiba",
+      city: "funabashi",
+      equipments: [],
+      sort: "freshness",
+      page: 1,
+      perPage: 20,
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith("/gyms/search", {
+      method: "GET",
+      query: {
+        q: "deadlift",
+        pref: "chiba",
+        city: "funabashi",
+        equipments: "",
+        equipment_match: undefined,
+        sort: "freshness",
+        page: 1,
+        per_page: 20,
+        page_token: undefined,
+      },
+      signal: undefined,
+    });
+  });
+
   it("normalizes the response payload into GymSummary items", async () => {
     apiRequest.mockResolvedValue({
       items: [

--- a/frontend/src/types/meta.ts
+++ b/frontend/src/types/meta.ts
@@ -4,4 +4,5 @@ export interface MetaOption {
 }
 
 export type PrefectureOption = MetaOption;
+export type CityOption = MetaOption;
 export type EquipmentCategoryOption = MetaOption;


### PR DESCRIPTION
ジム一覧検索に city / sort / 距離(プレースホルダ) フィルタ追加。
URLクエリ同期 (q,prefecture,city,equipment,sort,page,per_page)。
デフォルト件数 20 に統一。
テスト拡張: searchGyms / useGymSearch / searchParams。
ドキュメント: docs/web-search.md 追加 / ARCHITECTURE.md に検索層節追記。