### PR TITLE
feat: ジム詳細ページに報告リンクを追加

### DIFF
--- a/frontend/app/gyms/[slug]/page.tsx
+++ b/frontend/app/gyms/[slug]/page.tsx
@@ -1,5 +1,24 @@
+import Link from "next/link";
+
 import { GymDetailPage } from "./GymDetailPage";
 
 export default function GymDetailRoute({ params }: { params: { slug: string } }) {
-  return <GymDetailPage slug={params.slug} />;
+  const { slug } = params;
+
+  return (
+    <>
+      <GymDetailPage slug={slug} />
+      <div className="px-4 pb-10">
+        <div className="mx-auto w-full max-w-5xl">
+          <Link
+            aria-label="このジムの情報を報告する"
+            className="mt-6 inline-flex text-sm font-medium text-muted-foreground hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            href={`/gyms/${slug}/report`}
+          >
+            このジム情報に問題がありますか？報告する
+          </Link>
+        </div>
+      </div>
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- ジム詳細ページの末尾に「このジム情報に問題がありますか？報告する」リンクを追加し、UI の余白を確保しました
- next/link を利用して /gyms/[slug]/report へ遷移するようにし、aria-label でアクセシビリティに配慮しました
- フォーカス時のリングを含むスタイルを適用し、既存デザイン指針 (Tailwind + shadcn/ui) に沿う形にしました

## Testing
- npm run typecheck
- 任意のスラッグで /gyms/[slug] を表示し、末尾にリンクが表示されることを確認
- リンクをクリックして /gyms/[slug]/report へ遷移することを確認

------
https://chatgpt.com/codex/tasks/task_e_68d16ff246a4832aa1605b0353e233b9