### PR TITLE
Fix Alembic configuration default for migrations

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,6 @@
+"""Application package initialization."""
+
+# Ensure Alembic configurations are patched before tests set up databases.
+from . import _alembic_config as _alembic_config_patch  # noqa: F401
+
+__all__ = []

--- a/app/_alembic_config.py
+++ b/app/_alembic_config.py
@@ -1,0 +1,42 @@
+"""Utilities to ensure Alembic always finds the migration scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_MIGRATIONS_PATH = _PROJECT_ROOT / "migrations"
+
+
+def _ensure_script_location(config: Any) -> None:
+    """Ensure Alembic configurations always know where migrations live."""
+    try:
+        script_location = config.get_main_option("script_location")
+    except Exception:
+        return
+    if script_location:
+        return
+    if not _MIGRATIONS_PATH.exists():
+        return
+    config.set_main_option("script_location", str(_MIGRATIONS_PATH))
+    if not config.get_main_option("prepend_sys_path"):
+        config.set_main_option("prepend_sys_path", str(_PROJECT_ROOT))
+
+
+try:  # pragma: no cover - optional dependency during import
+    from alembic.config import Config as AlembicConfig
+except Exception:  # pragma: no cover - Alembic might not be installed
+    AlembicConfig = None  # type: ignore[assignment]
+else:
+    if not getattr(AlembicConfig, "_ged_patched", False):
+        _original_init = AlembicConfig.__init__
+
+        def _patched_init(self, *args: Any, **kwargs: Any) -> None:
+            _original_init(self, *args, **kwargs)
+            _ensure_script_location(self)
+
+        AlembicConfig.__init__ = _patched_init  # type: ignore[assignment]
+        AlembicConfig._ged_patched = True  # type: ignore[attr-defined]
+
+__all__ = []


### PR DESCRIPTION
## Summary
- add a small helper that patches `alembic.config.Config` to fill in the migrations directory when `script_location` is missing
- import the helper during package initialisation so the patch is applied before tests construct Alembic configs

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'asyncpg')*


------
https://chatgpt.com/codex/tasks/task_e_68d2c7409f5c832a84f84649c9ed39a9