### PR TITLE
[BE-1] Minimal test foundation (smoke only, fast on PR)

### DIFF
--- a/.github/workflows/pr-light.yml
+++ b/.github/workflows/pr-light.yml
@@ -72,29 +72,11 @@ jobs:
         run: ruff check .
 
   backend-tests:
-    name: Backend tests (async)
+    name: Backend smoke tests
     needs: detect-backend-changes
     if: needs.detect-backend-changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      POSTGRES_DB: gym_test
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: pass
-      POSTGRES_PORT: 5432
-      TEST_DATABASE_URL: postgresql+asyncpg://postgres:pass@localhost:5432/gym_test
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_DB: gym_test
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pass
-        ports:
-          - '5432:5432'
-        options: >-
-          --health-cmd="pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"
-          --health-interval=10s --health-timeout=5s --health-retries=10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -122,15 +104,8 @@ jobs:
           pip install -r requirements.txt
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
-      - name: Run Alembic migrations
-        env:
-          ALEMBIC_DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
-        run: alembic upgrade head
-
-      - name: Run pytest (no coverage)
-        env:
-          TEST_DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
-        run: pytest -q
+      - name: Run backend smoke tests
+        run: pytest -q -m "smoke"
 
   skip-message:
     name: Skip backend tests when not needed

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Minimal pytest fixtures for fast backend smoke tests."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Ensure the FastAPI app boots in testing mode before it is imported.
+os.environ.setdefault("TESTING", "1")
+os.environ.setdefault("APP_ENV", "test")
+os.environ.setdefault("SENTRY_DSN", "")
+# Ensure score weights sum to 1.0 even if the developer has custom env overrides set.
+os.environ.setdefault("SCORE_W_FRESH", "0.6")
+os.environ.setdefault("SCORE_W_RICH", "0.4")
+
+from app.main import create_app  # noqa: E402 (import after env tweaks)
+
+
+@pytest.fixture(scope="session")
+def app() -> FastAPI:
+    """Return a FastAPI application instance configured for tests."""
+    return create_app()
+
+
+@pytest.fixture(scope="session")
+def client(app: FastAPI) -> Iterator[TestClient]:
+    """Provide a TestClient for smoke tests."""
+    with TestClient(app) as test_client:
+        yield test_client

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -1,0 +1,26 @@
+"""Backend smoke tests that avoid touching the database."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.smoke
+def test_healthz_endpoint_is_up(client: TestClient) -> None:
+    """/healthz should be reachable without hitting the database."""
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("ok") is True
+
+
+@pytest.mark.smoke
+def test_openapi_schema_is_available(client: TestClient) -> None:
+    """The OpenAPI schema should be served for lightweight validation."""
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    schema = response.json()
+    assert "openapi" in schema
+    assert "paths" in schema
+    assert "/healthz" in schema["paths"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,9 @@
 [pytest]
 pythonpath = .
 asyncio_mode = auto
+testpaths = backend/tests
+addopts = -q
+markers =
+    smoke: Fast backend smoke tests that avoid external services.
 ; Note: If you want pytest to auto-load .env files, install pytest-dotenv and set
-; `dotenv_files = .env.test`. For portability, we load .env.test in tests/conftest.py.
+; `dotenv_files = .env.test` (plugin not included by default to keep the smoke suite minimal).


### PR DESCRIPTION
## 目的
- PRライトで高速に回る土台を整えるため

## 変更点
- pytest.ini に backend/tests を対象とする基本設定と smoke マーカーを追加
- backend/tests/conftest.py を新設し、DBレスな TestClient を提供しつつスコア計算の環境変数をデフォルト化
- backend/tests/test_smoke.py を追加し、/healthz と /openapi.json の Smoke テストを実装
- PR Light CI で DB サービスを起動せず `pytest -q -m "smoke"` のみを実行するように調整

## 影響範囲
- DB依存テストは含まれず、将来的な BE-3 以降で拡張予定

## 確認方法
- pytest -q -m "smoke"
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d34de10c78832a98202492fe66c867