### PR TITLE
[BE-2] Pure unit tests (DB-less) + ruff formatting

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,0 +1,48 @@
+name: Backend unit tests (DB-less)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  unit-tests:
+    name: Backend unit tests (no DB)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Determine pip cache directory
+        id: pip-cache-dir
+        run: echo "dir=$(python -m pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache-dir.outputs.dir }}
+          key: pip-${{ runner.os }}-3.11-${{ hashFiles('requirements*.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-3.11-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip wheel setuptools
+          pip install -r requirements.txt
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+
+      - name: Run format check
+        run: ruff format --check .
+
+      - name: Run lint check
+        run: ruff check .
+
+      - name: Run backend unit tests
+        run: pytest -q -m "unit"

--- a/backend/tests/unit/test_geo.py
+++ b/backend/tests/unit/test_geo.py
@@ -1,0 +1,75 @@
+"""Unit tests for geo-related helpers and pagination tokens."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from app.services import gym_nearby, gym_search_api
+from app.services.gym_search_api import GymSortKey
+
+pytestmark = pytest.mark.unit
+
+
+def test_nearby_token_roundtrip_preserves_values() -> None:
+    token = gym_nearby._encode_page_token_for_nearby(12.3456789, 42)
+
+    distance, last_id = gym_nearby._validate_and_decode_page_token(token)
+
+    assert distance == pytest.approx(12.345679, abs=1e-6)
+    assert last_id == 42
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "not-a-token",
+        gym_nearby._b64e({"sort": "nearby"}),
+        gym_nearby._b64e({"sort": "nearby", "k": [1, 2, 3]}),
+        gym_nearby._b64e({"sort": "something-else", "k": [1, 2]}),
+        gym_nearby._b64e({"sort": "nearby", "k": ["not-a-number", 5]}),
+    ],
+)
+def test_nearby_token_validation_rejects_invalid_payloads(token: str) -> None:
+    with pytest.raises(ValueError):
+        gym_nearby._validate_and_decode_page_token(token)
+
+
+def test_iso_helper_filters_invalid_dates() -> None:
+    assert gym_nearby._iso(None) is None
+    assert gym_nearby._iso(datetime(1960, 1, 1)) is None
+
+    dt = datetime(2024, 5, 1, 12, 30, 45)
+    assert gym_nearby._iso(dt) == dt.isoformat()
+
+
+def test_distance_token_roundtrip_uses_six_decimal_precision() -> None:
+    token = gym_search_api._encode_page_token_for_distance(987.6543219, 7)
+
+    distance, last_id = gym_search_api._validate_and_decode_page_token(token, GymSortKey.distance)
+
+    assert distance == pytest.approx(987.654322, abs=1e-6)
+    assert last_id == 7
+
+
+def test_distance_token_validation_checks_sort_match() -> None:
+    token = gym_search_api._encode_page_token_for_distance(1.0, 9)
+
+    with pytest.raises(ValueError):
+        gym_search_api._validate_and_decode_page_token(token, GymSortKey.richness)
+
+
+def test_distance_token_validation_detects_wrong_shape() -> None:
+    token = gym_search_api._b64e({"sort": GymSortKey.distance.value, "k": [1, 2, 3]})
+
+    with pytest.raises(ValueError):
+        gym_search_api._validate_and_decode_page_token(token, GymSortKey.distance)
+
+
+def test_last_verified_formatter_returns_iso_strings() -> None:
+    assert gym_search_api._lv(None) is None
+    assert gym_search_api._lv(datetime(1965, 1, 1)) is None
+
+    dt = datetime(2023, 11, 3, 9, 15, 0)
+    assert gym_search_api._lv(dt) == dt.isoformat()

--- a/backend/tests/unit/test_query_params.py
+++ b/backend/tests/unit/test_query_params.py
@@ -1,0 +1,72 @@
+"""Unit tests for pagination and sort normalization helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.utils.paging import build_next_offset_token, parse_offset_token
+from app.utils.sort import resolve_sort_key
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("token", "page", "per_page", "expected"),
+    [
+        (None, 1, 20, 0),
+        (None, 3, 15, 30),
+        ("5", 1, 20, 5),
+    ],
+)
+def test_parse_offset_token_handles_none_and_numeric(
+    token: str | None,
+    page: int,
+    per_page: int,
+    expected: int,
+) -> None:
+    assert parse_offset_token(token, page=page, per_page=per_page) == expected
+
+
+@pytest.mark.parametrize("token", ["", "abc", "1.5"])
+def test_parse_offset_token_rejects_invalid_strings(token: str) -> None:
+    with pytest.raises(ValueError):
+        parse_offset_token(token, page=1, per_page=20)
+
+
+@pytest.mark.parametrize(
+    ("offset", "per_page", "total", "expected"),
+    [
+        (0, 10, 25, "10"),
+        (15, 10, 30, "25"),
+        (20, 10, 30, None),
+        (30, 10, 30, None),
+    ],
+)
+def test_build_next_offset_token_detects_end_of_results(
+    offset: int,
+    per_page: int,
+    total: int,
+    expected: str | None,
+) -> None:
+    assert build_next_offset_token(offset, per_page, total) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, "freshness"),
+        ("", "freshness"),
+        ("recent", "freshness"),
+        ("UPDATED", "freshness"),
+        ("richness", "richness"),
+        ("score", "richness"),
+        ("RANK", "richness"),
+        ("gym_name", "gym_name"),
+        ("Name", "gym_name"),
+        ("created", "created_at"),
+        ("distance", "freshness"),
+        ("unknown", "freshness"),
+    ],
+)
+def test_resolve_sort_key_normalizes_aliases(raw: str | None, expected: str) -> None:
+    assert resolve_sort_key(raw) == expected

--- a/backend/tests/unit/test_validation.py
+++ b/backend/tests/unit/test_validation.py
@@ -1,0 +1,105 @@
+"""Unit tests for strict search query validation schemas."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.schemas.gym_search import GymSearchQuery
+
+pytestmark = pytest.mark.unit
+
+
+def test_slug_fields_are_trimmed() -> None:
+    query = GymSearchQuery(pref="  tokyo-01  ", city="  funabashi  ")
+
+    assert query.pref == "tokyo-01"
+    assert query.city == "funabashi"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "detail"),
+    [
+        ("pref", "   ", "empty string is not allowed"),
+        ("pref", "Tokyo", "invalid slug"),
+        ("city", "kyoto!", "invalid slug"),
+    ],
+)
+def test_slug_fields_reject_invalid_inputs(field: str, value: str, detail: str) -> None:
+    with pytest.raises(HTTPException) as exc:
+        GymSearchQuery(**{field: value})
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == detail
+
+
+@pytest.mark.parametrize("value", [0, -1, 101])
+def test_page_size_must_be_within_bounds(value: int) -> None:
+    with pytest.raises(HTTPException) as exc:
+        GymSearchQuery(page_size=value)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "page_size must be between 1 and 100"
+
+
+def test_page_must_be_positive() -> None:
+    with pytest.raises(HTTPException) as exc:
+        GymSearchQuery(page=0)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "page must be >= 1"
+
+
+def test_equipments_csv_must_not_be_blank() -> None:
+    with pytest.raises(HTTPException) as exc:
+        GymSearchQuery(equipments="   ")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "equipments must not be empty"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_page_size"),
+    [
+        ({"page_size": 30, "per_page": 40, "limit": 50}, 30),
+        ({"page_size": None, "per_page": 25, "limit": 50}, 25),
+        ({"page_size": None, "per_page": None, "limit": 10}, 10),
+        ({"page_size": None, "per_page": None, "limit": None}, 20),
+    ],
+)
+def test_as_query_resolves_page_size_priority(
+    kwargs: dict[str, int | None],
+    expected_page_size: int,
+) -> None:
+    query = GymSearchQuery.as_query(**kwargs)
+
+    assert query.page_size == expected_page_size
+
+
+def test_as_query_invalid_page_size_propagates_http_exception() -> None:
+    with pytest.raises(HTTPException) as exc:
+        GymSearchQuery.as_query(page_size=0)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "page_size must be between 1 and 100"
+
+
+def test_as_query_blank_equipments_propagates_http_exception() -> None:
+    with pytest.raises(HTTPException) as exc:
+        GymSearchQuery.as_query(equipments="   ")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "equipments must not be empty"
+
+
+def test_lat_lng_bounds_are_enforced() -> None:
+    query = GymSearchQuery.model_validate({"lat": 90.0, "lng": -180.0})
+
+    assert query.lat == pytest.approx(90.0)
+    assert query.lng == pytest.approx(-180.0)
+
+
+def test_latitude_out_of_range_raises_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        GymSearchQuery.model_validate({"lat": 90.0001})

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,5 +5,6 @@ testpaths = backend/tests
 addopts = -q
 markers =
     smoke: Fast backend smoke tests that avoid external services.
+    unit: DB非依存のピュアユニット
 ; Note: If you want pytest to auto-load .env files, install pytest-dotenv and set
 ; `dotenv_files = .env.test` (plugin not included by default to keep the smoke suite minimal).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,7 @@ ruff==0.12.12
 pre-commit==3.7.1
 mypy==1.11.2
 pytest-cov==5.0.0
+pytest>=8.0
+Faker>=19.0
+httpx>=0.27
+anyio>=4.0


### PR DESCRIPTION
## 目的
- DB非依存の純ロジックテスト追加。PRライトCIは維持。

## 変更
- unitテスト新設、pytest.iniにunitマーカー、ruff整形の適用。

## 確認
- ruff format --check && ruff check . && pytest -m unit が通ること。


------
https://chatgpt.com/codex/tasks/task_e_68d3564e6448832a81ff825843570efc