### PR TITLE
[BE-3] Minimal API integration tests + integration CI (manual/main only)

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,0 +1,69 @@
+name: Backend integration tests (Postgres)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  integration-tests:
+    name: Backend integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: gym_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: pass
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d gym_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      TEST_DATABASE_URL: postgresql+asyncpg://postgres:pass@localhost:5432/gym_test
+      DATABASE_URL: postgresql+asyncpg://postgres:pass@localhost:5432/gym_test
+      ALEMBIC_DATABASE_URL: postgresql+asyncpg://postgres:pass@localhost:5432/gym_test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Determine pip cache directory
+        id: pip-cache-dir
+        run: echo "dir=$(python -m pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache-dir.outputs.dir }}
+          key: pip-${{ runner.os }}-3.11-${{ hashFiles('requirements*.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-3.11-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip wheel setuptools
+          pip install -r requirements.txt
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+
+      - name: Run format check
+        run: ruff format --check .
+
+      - name: Run lint check
+        run: ruff check .
+
+      - name: Run database migrations
+        run: alembic upgrade head
+
+      - name: Run integration tests
+        run: pytest -q -m "integration"

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,0 +1,53 @@
+"""Integration test fixtures that boot the app against a Postgres database."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="session")
+def integration_client() -> Iterator[TestClient]:
+    """Provide a TestClient wired to the FastAPI app using TEST_DATABASE_URL."""
+    test_url = os.getenv("TEST_DATABASE_URL")
+    if not test_url:
+        pytest.skip("TEST_DATABASE_URL is required for integration tests")
+
+    os.environ["DATABASE_URL"] = test_url
+    os.environ.setdefault("APP_ENV", "test")
+    os.environ.setdefault("TESTING", "1")
+    os.environ.setdefault("SENTRY_DSN", "")
+    os.environ.setdefault("SCORE_W_FRESH", "0.6")
+    os.environ.setdefault("SCORE_W_RICH", "0.4")
+
+    # Reload DB/session providers to ensure they use the test database URL.
+    db_module = sys.modules.get("app.db")
+    if db_module is not None:
+        old_engine = getattr(db_module, "engine", None)
+        if old_engine is not None:
+            try:
+                old_engine.sync_engine.dispose()
+            except Exception:  # noqa: BLE001 - best effort cleanup
+                pass
+        importlib.reload(db_module)
+    else:
+        db_module = importlib.import_module("app.db")
+
+    for module_name in ("app.api.deps",):
+        module = sys.modules.get(module_name)
+        if module is not None:
+            importlib.reload(module)
+        else:
+            importlib.import_module(module_name)
+
+    main_module = importlib.import_module("app.main")
+    main_module = importlib.reload(main_module)
+    app = main_module.create_app()
+
+    with TestClient(app) as client:
+        yield client

--- a/backend/tests/integration/test_health.py
+++ b/backend/tests/integration/test_health.py
@@ -1,0 +1,24 @@
+"""Integration tests covering service readiness/health endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = [pytest.mark.integration]
+
+
+def test_health_endpoint_reports_ok(integration_client: TestClient) -> None:
+    """/health should respond with a JSON payload when the app boots."""
+    response = integration_client.get("/health")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload.get("status") == "ok"
+    assert "env" in payload
+
+
+def test_readyz_endpoint_checks_database(integration_client: TestClient) -> None:
+    """/readyz performs a database round trip and should succeed."""
+    response = integration_client.get("/readyz")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}

--- a/backend/tests/integration/test_public_endpoints.py
+++ b/backend/tests/integration/test_public_endpoints.py
@@ -1,0 +1,24 @@
+"""Integration smoke tests that hit representative public endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = [pytest.mark.integration]
+
+
+def test_gym_search_endpoint_returns_json(integration_client: TestClient) -> None:
+    """/gyms/search should respond with pagination metadata even on an empty database."""
+    response = integration_client.get("/gyms/search")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert isinstance(payload.get("items"), list)
+    assert "total" in payload
+    assert "page" in payload
+    assert "page_size" in payload
+    assert "has_more" in payload
+    assert "has_prev" in payload
+    # page_token may be null but must exist in the payload.
+    assert "page_token" in payload

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,37 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: gym_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: pass
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d gym_test"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+
+  api:
+    build:
+      context: .
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      APP_ENV: test
+      TESTING: "1"
+      SENTRY_DSN: ""
+      TEST_DATABASE_URL: postgresql+asyncpg://postgres:pass@db:5432/gym_test
+      DATABASE_URL: postgresql+asyncpg://postgres:pass@db:5432/gym_test
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c 'import sys, urllib.request; sys.exit(0 if urllib.request.urlopen(\"http://localhost:8000/readyz\").status == 200 else 1)'",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 12

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,6 @@ addopts = -q
 markers =
     smoke: Fast backend smoke tests that avoid external services.
     unit: DB非依存のピュアユニット
+    integration: DB/アプリ起動を伴う統合テスト
 ; Note: If you want pytest to auto-load .env files, install pytest-dotenv and set
 ; `dotenv_files = .env.test` (plugin not included by default to keep the smoke suite minimal).


### PR DESCRIPTION
目的：DB付きの最小統合テストを追加し、PRでは未実行にしてCI時間を節約
変更：integration テスト、pytest マーカー、integration 用ワークフロー
確認：ruff format --check && ruff check . && pytest -m integration がローカルOK。workflow_dispatch で成功

------
https://chatgpt.com/codex/tasks/task_e_68d35decd418832a904a1b8dbd37d916