### PR TITLE
[BE-4] Fast unit tests for repo/service (PR-light CI only)

### DIFF
--- a/.github/workflows/pr-light.yml
+++ b/.github/workflows/pr-light.yml
@@ -72,7 +72,7 @@ jobs:
         run: ruff check .
 
   backend-tests:
-    name: Backend smoke tests
+    name: Backend unit tests
     needs: detect-backend-changes
     if: needs.detect-backend-changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
@@ -104,8 +104,8 @@ jobs:
           pip install -r requirements.txt
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
-      - name: Run backend smoke tests
-        run: pytest -q -m "smoke"
+      - name: Run backend unit tests
+        run: pytest -q -m "unit"
 
   skip-message:
     name: Skip backend tests when not needed
@@ -114,4 +114,4 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - run: echo "No backend-related changes detected; database tests were skipped."
+      - run: echo "No backend-related changes detected; backend unit tests were skipped."

--- a/backend/tests/unit/test_gym_search_service.py
+++ b/backend/tests/unit/test_gym_search_service.py
@@ -1,0 +1,178 @@
+"""Unit tests for gym_search service logic without talking to the DB."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+
+from app.repositories.interfaces import GymEquipmentSummaryRow
+from app.services.gym_search import search_gyms
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _FakeGym:
+    id: int
+    slug: str
+    name: str
+    pref: str = "tokyo"
+    city: str = "shinjuku"
+    last_verified_at_cached: datetime | None = None
+
+
+class _FakeGymRepository:
+    def __init__(self, gyms: list[_FakeGym], equipment_rows: list[GymEquipmentSummaryRow]) -> None:
+        self._gyms = gyms
+        self._equipment_rows = equipment_rows
+        self.fetch_calls: list[tuple[list[int], list[str] | None]] = []
+
+    async def list_by_pref_city(self, *, pref: str | None, city: str | None) -> list[_FakeGym]:
+        self.list_args = {"pref": pref, "city": city}
+        return self._gyms
+
+    async def fetch_equipment_for_gyms(
+        self,
+        *,
+        gym_ids: list[int],
+        equipment_slugs: list[str] | None,
+    ) -> list[GymEquipmentSummaryRow]:
+        self.fetch_calls.append((list(gym_ids), list(equipment_slugs) if equipment_slugs else None))
+        return list(self._equipment_rows)
+
+    async def created_at_map(self, gym_ids: list[int]) -> dict[int, datetime | None]:
+        self.created_at_inputs = list(gym_ids)
+        return {gid: None for gid in gym_ids}
+
+
+class _FakeUnitOfWork:
+    def __init__(self, gym_repo: _FakeGymRepository) -> None:
+        self.gyms = gym_repo
+
+
+@pytest.mark.asyncio
+async def test_search_filters_to_gyms_with_all_requested_equipments() -> None:
+    gyms = [
+        _FakeGym(id=1, slug="alpha-gym", name="Alpha Gym"),
+        _FakeGym(id=2, slug="beta-gym", name="Beta Gym"),
+    ]
+    rows = [
+        GymEquipmentSummaryRow(
+            gym_id=1,
+            slug="rack",
+            name="Power Rack",
+            category=None,
+            count=3,
+            max_weight_kg=90.0,
+            availability="present",
+            verification_status="verified",
+            last_verified_at=datetime(2024, 5, 1, 12, 0, 0),
+            source=None,
+        ),
+        GymEquipmentSummaryRow(
+            gym_id=1,
+            slug="bench",
+            name="Bench Press",
+            category=None,
+            count=1,
+            max_weight_kg=None,
+            availability="present",
+            verification_status="verified",
+            last_verified_at=datetime(2024, 5, 5, 18, 30, 0),
+            source=None,
+        ),
+        GymEquipmentSummaryRow(
+            gym_id=2,
+            slug="bench",
+            name="Bench Press",
+            category=None,
+            count=4,
+            max_weight_kg=100.0,
+            availability="present",
+            verification_status="verified",
+            last_verified_at=datetime(2024, 4, 20, 9, 0, 0),
+            source=None,
+        ),
+    ]
+    repo = _FakeGymRepository(gyms, rows)
+    uow = _FakeUnitOfWork(repo)
+
+    page = await search_gyms(
+        uow,
+        pref="tokyo",
+        city=None,
+        equipments=["rack", "bench"],
+        equipment_match="all",
+        sort="richness",
+        page_token=None,
+        page=1,
+        per_page=10,
+    )
+
+    assert [item.id for item in page.items] == [1]
+    assert page.total == 1
+    assert page.items[0].score == pytest.approx(2.5)
+    assert page.items[0].last_verified_at == datetime(2024, 5, 5, 18, 30).isoformat()
+    assert repo.fetch_calls == [([1, 2], ["rack", "bench"])], "equipment filter should be forwarded"
+
+
+@pytest.mark.asyncio
+async def test_search_sorts_by_latest_verification_when_sorting_by_freshness() -> None:
+    gyms = [
+        _FakeGym(
+            id=1,
+            slug="alpha-gym",
+            name="Alpha Gym",
+            last_verified_at_cached=datetime(2024, 1, 10, 9, 0, 0),
+        ),
+        _FakeGym(id=2, slug="beta-gym", name="Beta Gym"),
+    ]
+    rows = [
+        GymEquipmentSummaryRow(
+            gym_id=1,
+            slug="rack",
+            name="Power Rack",
+            category=None,
+            count=2,
+            max_weight_kg=80.0,
+            availability="present",
+            verification_status="verified",
+            last_verified_at=datetime(2024, 1, 5, 8, 0, 0),
+            source=None,
+        ),
+        GymEquipmentSummaryRow(
+            gym_id=2,
+            slug="bench",
+            name="Bench Press",
+            category=None,
+            count=2,
+            max_weight_kg=90.0,
+            availability="present",
+            verification_status="verified",
+            last_verified_at=datetime(2024, 2, 1, 10, 0, 0),
+            source=None,
+        ),
+    ]
+    repo = _FakeGymRepository(gyms, rows)
+    uow = _FakeUnitOfWork(repo)
+
+    page = await search_gyms(
+        uow,
+        pref=None,
+        city=None,
+        equipments=None,
+        equipment_match="any",
+        sort="freshness",
+        page_token=None,
+        page=1,
+        per_page=10,
+    )
+
+    assert [item.id for item in page.items] == [2, 1]
+    assert page.items[0].last_verified_at == datetime(2024, 2, 1, 10, 0).isoformat()
+    assert page.items[1].last_verified_at == datetime(2024, 1, 10, 9, 0).isoformat()
+    assert page.has_more is False
+    assert page.has_prev is False
+    assert page.page_token is None

--- a/backend/tests/unit/test_sqlalchemy_gym_repository.py
+++ b/backend/tests/unit/test_sqlalchemy_gym_repository.py
@@ -1,0 +1,83 @@
+"""Unit tests for the SQLAlchemy gym repository query helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.repositories.interfaces import GymEquipmentSummaryRow
+from app.repositories.sqlalchemy.gym import SqlAlchemyGymReadRepository
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeResult:
+    def __init__(self, rows: list[SimpleNamespace]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[SimpleNamespace]:
+        return self._rows
+
+
+@pytest.mark.asyncio
+async def test_fetch_equipment_for_gyms_converts_enums_and_applies_filters() -> None:
+    class Availability(Enum):
+        PRESENT = "present"
+
+    class Verification(Enum):
+        VERIFIED = "verified"
+
+    session = AsyncMock()
+    repo = SqlAlchemyGymReadRepository(session)
+
+    dt = datetime(2024, 6, 1, 9, 0, 0)
+    row = SimpleNamespace(
+        gym_id=1,
+        slug="rack",
+        name="Power Rack",
+        category="strength",
+        availability=Availability.PRESENT,
+        verification_status=Verification.VERIFIED,
+        last_verified_at=dt,
+        count=2,
+        max_weight_kg=180.0,
+        url="https://example.com",
+    )
+    session.execute.return_value = _FakeResult([row])
+
+    result = await repo.fetch_equipment_for_gyms(gym_ids=[1, 2], equipment_slugs=["rack"])
+
+    assert result == [
+        GymEquipmentSummaryRow(
+            gym_id=1,
+            slug="rack",
+            name="Power Rack",
+            category="strength",
+            count=2,
+            max_weight_kg=180.0,
+            availability="present",
+            verification_status="verified",
+            last_verified_at=dt,
+            source="https://example.com",
+        )
+    ]
+
+    stmt = session.execute.await_args.args[0]
+    where_clauses = {str(clause) for clause in stmt._where_criteria}
+    assert any("gym_equipments.gym_id" in clause for clause in where_clauses)
+    assert any("equipments.slug" in clause for clause in where_clauses)
+
+
+@pytest.mark.asyncio
+async def test_fetch_equipment_for_gyms_skips_query_when_no_ids() -> None:
+    session = AsyncMock()
+    repo = SqlAlchemyGymReadRepository(session)
+
+    result = await repo.fetch_equipment_for_gyms(gym_ids=[], equipment_slugs=["rack"])
+
+    assert result == []
+    session.execute.assert_not_called()

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ testpaths = backend/tests
 addopts = -q
 markers =
     smoke: Fast backend smoke tests that avoid external services.
-    unit: DB非依存のピュアユニット
+    unit: DBを使わない高速ユニットテスト
     integration: DB/アプリ起動を伴う統合テスト
 ; Note: If you want pytest to auto-load .env files, install pytest-dotenv and set
 ; `dotenv_files = .env.test` (plugin not included by default to keep the smoke suite minimal).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,8 @@ pre-commit==3.7.1
 mypy==1.11.2
 pytest-cov==5.0.0
 pytest>=8.0
+pytest-asyncio>=0.23
+pytest-mock>=3.12
 Faker>=19.0
 httpx>=0.27
 anyio>=4.0


### PR DESCRIPTION
目的：DB不要の高速ユニットテストを追加し、PRの所要時間を短縮
変更：backend/tests/unit/* 追加、ci.yml を unit のみ実行に変更
確認：ruff format --check && ruff check . && pytest -m unit がローカル/CIとも成功

------
https://chatgpt.com/codex/tasks/task_e_68d36446d5d8832ab2754e04b286aab6