### PR TITLE
[BE-5] Minimal integration tests + workflow split

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -10,7 +10,7 @@ jobs:
   integration-tests:
     name: Backend integration tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:16
@@ -64,6 +64,9 @@ jobs:
 
       - name: Run database migrations
         run: alembic upgrade head
+
+      - name: Seed minimal dataset for integration tests
+        run: python -m scripts.seed_min_test
 
       - name: Run integration tests
         run: pytest -q -m "integration"

--- a/backend/tests/integration/test_health.py
+++ b/backend/tests/integration/test_health.py
@@ -3,22 +3,22 @@
 from __future__ import annotations
 
 import pytest
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 
 pytestmark = [pytest.mark.integration]
 
 
-def test_health_endpoint_reports_ok(integration_client: TestClient) -> None:
+async def test_health_endpoint_reports_ok(integration_client: AsyncClient) -> None:
     """/health should respond with a JSON payload when the app boots."""
-    response = integration_client.get("/health")
+    response = await integration_client.get("/health")
     assert response.status_code == 200
     payload = response.json()
     assert payload.get("status") == "ok"
     assert "env" in payload
 
 
-def test_readyz_endpoint_checks_database(integration_client: TestClient) -> None:
+async def test_readyz_endpoint_checks_database(integration_client: AsyncClient) -> None:
     """/readyz performs a database round trip and should succeed."""
-    response = integration_client.get("/readyz")
+    response = await integration_client.get("/readyz")
     assert response.status_code == 200
     assert response.json() == {"ok": True}

--- a/backend/tests/integration/test_public_endpoints.py
+++ b/backend/tests/integration/test_public_endpoints.py
@@ -3,22 +3,72 @@
 from __future__ import annotations
 
 import pytest
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
+
+from scripts.seed_min_test import MINIMAL_GYM_DATASET
 
 pytestmark = [pytest.mark.integration]
 
+_NEARBY_PARAMS = {"lat": 35.6595, "lng": 139.7005, "radius_km": 5.0}
 
-def test_gym_search_endpoint_returns_json(integration_client: TestClient) -> None:
-    """/gyms/search should respond with pagination metadata even on an empty database."""
-    response = integration_client.get("/gyms/search")
+
+async def test_gym_nearby_endpoint_returns_seed_data(integration_client: AsyncClient) -> None:
+    """/gyms/nearby should return the seeded dataset with full pagination metadata."""
+    response = await integration_client.get(
+        "/gyms/nearby",
+        params={**_NEARBY_PARAMS, "page_size": 5},
+    )
     assert response.status_code == 200
     payload = response.json()
 
-    assert isinstance(payload.get("items"), list)
-    assert "total" in payload
-    assert "page" in payload
-    assert "page_size" in payload
-    assert "has_more" in payload
-    assert "has_prev" in payload
-    # page_token may be null but must exist in the payload.
-    assert "page_token" in payload
+    assert payload["total"] == len(MINIMAL_GYM_DATASET)
+    assert payload["page"] == 1
+    assert payload["page_size"] == 5
+    assert payload["has_more"] is False
+    assert payload["has_prev"] is False
+    assert payload["page_token"] is None
+
+    items = payload.get("items", [])
+    assert len(items) == len(MINIMAL_GYM_DATASET)
+
+    first = items[0]
+    assert first["slug"] == "integration-hub-gym"
+    assert first["distance_km"] == pytest.approx(0.0, abs=1e-6)
+    expected_keys = {
+        "id",
+        "slug",
+        "name",
+        "pref",
+        "city",
+        "latitude",
+        "longitude",
+        "distance_km",
+        "last_verified_at",
+    }
+    assert expected_keys.issubset(first.keys())
+
+
+async def test_gym_nearby_endpoint_supports_offset_pagination(
+    integration_client: AsyncClient,
+) -> None:
+    """Offset pagination (page/page_size) should surface the second seeded gym on page 2."""
+    response = await integration_client.get(
+        "/gyms/nearby",
+        params={**_NEARBY_PARAMS, "page": 2, "page_size": 1},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["total"] == len(MINIMAL_GYM_DATASET)
+    assert payload["page"] == 2
+    assert payload["page_size"] == 1
+    assert payload["has_more"] is True
+    assert payload["has_prev"] is True
+    assert payload["page_token"] is None
+
+    items = payload.get("items", [])
+    assert len(items) == 1
+    second = items[0]
+    assert second["slug"] == "integration-riverside-gym"
+    assert second["distance_km"] == pytest.approx(0.214907, rel=1e-3)
+    assert {"id", "slug", "name"}.issubset(second.keys())

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,8 +4,8 @@ asyncio_mode = auto
 testpaths = backend/tests
 addopts = -q
 markers =
-    smoke: Fast backend smoke tests that avoid external services.
-    unit: DBを使わない高速ユニットテスト
-    integration: DB/アプリ起動を伴う統合テスト
+    smoke: "Fast backend smoke tests that avoid external services."
+    unit: "DBを使わない高速ユニットテスト"
+    integration: "DBありの統合テスト（遅い）"
 ; Note: If you want pytest to auto-load .env files, install pytest-dotenv and set
 ; `dotenv_files = .env.test` (plugin not included by default to keep the smoke suite minimal).

--- a/scripts/seed_min_test.py
+++ b/scripts/seed_min_test.py
@@ -1,0 +1,87 @@
+"""Lightweight dataset seeding utility for integration tests."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import UTC, datetime
+from typing import Final
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models.gym import Gym
+
+MINIMAL_GYM_DATASET: Final[list[dict[str, object]]] = [
+    {
+        "name": "Integration Hub Gym",
+        "slug": "integration-hub-gym",
+        "pref": "tokyo",
+        "city": "shibuya",
+        "address": "1-2-3 Integration Ave, Shibuya-ku, Tokyo",
+        "latitude": 35.6595,
+        "longitude": 139.7005,
+        "last_verified_at_cached": datetime(2024, 5, 1, tzinfo=UTC),
+    },
+    {
+        "name": "Integration Riverside Gym",
+        "slug": "integration-riverside-gym",
+        "pref": "tokyo",
+        "city": "shibuya",
+        "address": "4-5-6 Riverside Road, Shibuya-ku, Tokyo",
+        "latitude": 35.658,
+        "longitude": 139.702,
+        "last_verified_at_cached": datetime(2024, 4, 10, tzinfo=UTC),
+    },
+    {
+        "name": "Integration West Gym",
+        "slug": "integration-west-gym",
+        "pref": "tokyo",
+        "city": "shibuya",
+        "address": "7-8-9 West Street, Shibuya-ku, Tokyo",
+        "latitude": 35.657,
+        "longitude": 139.695,
+        "last_verified_at_cached": datetime(2024, 3, 5, tzinfo=UTC),
+    },
+]
+
+
+async def seed_minimal_dataset(*, database_url: str | None = None) -> None:
+    """Replace the gyms table contents with a deterministic minimal dataset."""
+    url = database_url or os.getenv("TEST_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not url:
+        raise RuntimeError("TEST_DATABASE_URL or DATABASE_URL must be set for seeding")
+
+    print(f"[seed_min_test] Using database URL: {url}")
+    engine = create_async_engine(url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with session_factory() as session:
+        await _seed_gyms(session)
+
+    await engine.dispose()
+    print("[seed_min_test] Seeded minimal gyms dataset")
+
+
+async def _seed_gyms(session: AsyncSession) -> None:
+    """Clear gyms and insert the minimal dataset."""
+    print("[seed_min_test] Clearing gyms table")
+    async with session.begin():
+        await session.execute(delete(Gym))
+        for payload in MINIMAL_GYM_DATASET:
+            session.add(Gym(**payload))
+
+    total = await session.scalar(select(func.count()).select_from(Gym))
+    print(f"[seed_min_test] gyms table now contains {int(total or 0)} rows")
+
+
+async def _async_main() -> None:
+    await seed_minimal_dataset()
+
+
+def main() -> None:
+    asyncio.run(_async_main())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- 目的：PRライトCIを維持しつつ、main/手動のみ統合テストを実行
- 変更：backend/tests/integration/* 強化、軽量 seed ユーティリティ追加、test-integration.yml に Postgres + seed 実行を組み込み（ci.yml は unit のみ継続）
- 確認：ruff 通過、pytest -m unit 成功、pytest -m integration（TEST_DATABASE_URL 未設定のためスキップ）

------
https://chatgpt.com/codex/tasks/task_e_68d36ae6af08832aa8761783fc9f687d