### PR TITLE
[FE-2] MSW統合テスト（検索/距離/ページネーション）+ PRライトCI

### DIFF
--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -28,3 +28,5 @@ jobs:
         run: npm run typecheck
       - name: Run unit tests
         run: npm run test:unit
+      - name: Run integration tests
+        run: npm run test:integration

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -58,6 +58,7 @@ async def integration_client() -> AsyncIterator[httpx.AsyncClient]:
 
     lifespan_ctx = app.router.lifespan_context
     if lifespan_ctx is None:
+
         @contextlib.asynccontextmanager
         async def _lifespan():
             await app.router.startup()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,7 @@
         "eslint": "^8.57.1",
         "eslint-config-next": "14.2.5",
         "jsdom": "^25.0.1",
+        "msw": "^2.11.3",
         "postcss": "^8.4.49",
         "prettier": "^3.3.3",
         "tailwindcss": "^3.4.13",
@@ -417,6 +418,26 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1134,6 +1155,131 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.0.tgz",
+      "integrity": "sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.18.tgz",
+      "integrity": "sha512-MilmWOzHa3Ks11tzvuAmFoAd/wRuaP3SwlT1IZhyMke31FKLxPiuDWcGXhU+PKveNOpAc4axzAgrgxuIJJRmLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-yXq/4QUnk4sHMtmbd7irwiepjB8jXU0kkFRL4nr/aDBA2mDz13cMakEWdDwX3eSCTkk03kwcndD1zfRAIlELxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1316,6 +1462,24 @@
         "geojson-vt": "^4.0.2",
         "pbf": "^4.0.1",
         "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.6.tgz",
+      "integrity": "sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1535,6 +1699,31 @@
       "engines": {
         "node": ">=12.4.0"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3505,6 +3694,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3571,6 +3767,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
@@ -4831,11 +5034,76 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -4899,6 +5167,16 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -6232,6 +6510,16 @@
       "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
       "license": "ISC"
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6474,6 +6762,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6566,6 +6864,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -6948,6 +7253,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -7624,11 +7936,113 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.11.3.tgz",
+      "integrity": "sha512-878imp8jxIpfzuzxYfX0qqTq1IFQz/1/RBHs/PyirSjzi+xKM/RRfIpIqHSCWjH0GxidrjhgiiXC+DWXNDvT9w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.39.1",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.7.0",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^4.26.1",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/tldts": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.16.tgz",
+      "integrity": "sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.16"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/msw/node_modules/tldts-core": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
+      "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw/node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/murmurhash-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -7952,6 +8366,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -8078,6 +8499,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -8608,6 +9036,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -8656,6 +9094,13 @@
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.7.0.tgz",
+      "integrity": "sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -9079,6 +9524,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -9107,6 +9562,13 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -9997,6 +10459,16 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -10594,6 +11066,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -10611,6 +11093,57 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yn": {
@@ -10631,6 +11164,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run --passWithNoTests",
-    "test:unit": "vitest run --passWithNoTests"
+    "test:unit": "vitest run --passWithNoTests --exclude \"tests/integration/**/*.int.test.ts*\"",
+    "test:integration": "vitest run --config vitest.config.ts --passWithNoTests -t 'int' tests/integration"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -50,6 +51,7 @@
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.5",
     "jsdom": "^25.0.1",
+    "msw": "^2.11.3",
     "postcss": "^8.4.49",
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.13",

--- a/frontend/tests/integration/DistanceFilter.int.test.tsx
+++ b/frontend/tests/integration/DistanceFilter.int.test.tsx
@@ -1,0 +1,194 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { vi } from "vitest";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
+import { server } from "../msw/server";
+import { GymsPage } from "@/features/gyms/GymsPage";
+import { Toaster } from "@/components/ui/toaster";
+
+class TestReadonlyURLSearchParams extends URLSearchParams {
+  append(): void {
+    throw new Error("append is not supported in tests");
+  }
+
+  delete(): void {
+    throw new Error("delete is not supported in tests");
+  }
+
+  set(): void {
+    throw new Error("set is not supported in tests");
+  }
+}
+
+const createSearchParams = (init: string = ""): ReadonlyURLSearchParams => {
+  return new TestReadonlyURLSearchParams(init) as unknown as ReadonlyURLSearchParams;
+};
+
+let mockSearchParams = createSearchParams();
+
+const updateSearchParamsFromUrl = (url: string) => {
+  const queryIndex = url.indexOf("?");
+  const query = queryIndex >= 0 ? url.slice(queryIndex + 1) : "";
+  mockSearchParams = createSearchParams(query);
+};
+
+const mockRouter = {
+  push: vi.fn((url: string) => {
+    updateSearchParamsFromUrl(url);
+  }),
+};
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+  usePathname: () => "/gyms",
+  useSearchParams: () => mockSearchParams,
+}));
+
+const renderGymsPage = () =>
+  render(
+    <>
+      <GymsPage />
+      <Toaster />
+    </>,
+  );
+
+const setSearchParams = (query: string) => {
+  mockSearchParams = createSearchParams(query);
+};
+
+type GeolocationMock = Pick<Geolocation, "getCurrentPosition" | "watchPosition" | "clearWatch">;
+
+const applyGeolocationMock = (mock: GeolocationMock) => {
+  Object.defineProperty(navigator, "geolocation", {
+    configurable: true,
+    value: mock as Geolocation,
+  });
+  return mock;
+};
+
+const createSuccessGeolocation = (lat: number, lng: number) => {
+  const mock: GeolocationMock = {
+    getCurrentPosition: vi.fn((success) => {
+      success({
+        coords: {
+          accuracy: 5,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          latitude: lat,
+          longitude: lng,
+          speed: null,
+        },
+        timestamp: Date.now(),
+      } as GeolocationPosition);
+    }),
+    watchPosition: vi.fn(),
+    clearWatch: vi.fn(),
+  };
+  return applyGeolocationMock(mock);
+};
+
+describe("Distance filter integration", () => {
+  let originalGeolocation: Geolocation | undefined;
+
+  beforeEach(() => {
+    originalGeolocation = navigator.geolocation;
+    setSearchParams("");
+    mockRouter.push.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalGeolocation) {
+      Object.defineProperty(navigator, "geolocation", {
+        configurable: true,
+        value: originalGeolocation,
+      });
+    } else {
+      Object.defineProperty(navigator, "geolocation", {
+        configurable: true,
+        value: undefined,
+      });
+    }
+  });
+
+  it("applies the selected radius to the API query and updates the list", async () => {
+    createSuccessGeolocation(35.68, 139.76);
+
+    const searchRequests: URL[] = [];
+    const radiusFiveResponse = {
+      items: [
+        {
+          id: 101,
+          slug: "five-km-gym",
+          name: "半径5kmトレーニングジム",
+          city: "chiyoda",
+          pref: "tokyo",
+          equipments: ["ダンベル"],
+          thumbnail_url: null,
+          last_verified_at: "2024-03-15T10:00:00Z",
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      per_page: 20,
+      has_next: false,
+      has_prev: false,
+      has_more: false,
+      page_token: null,
+    };
+    const radiusTenResponse = {
+      items: [
+        {
+          id: 102,
+          slug: "ten-km-gym",
+          name: "半径10kmフィットネスセンター",
+          city: "setagaya",
+          pref: "tokyo",
+          equipments: ["ランニングマシン"],
+          thumbnail_url: null,
+          last_verified_at: "2024-04-20T08:00:00Z",
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      per_page: 20,
+      has_next: false,
+      has_prev: false,
+      has_more: false,
+      page_token: null,
+    };
+
+    server.use(
+      http.get("*/gyms/search", ({ request }) => {
+        const url = new URL(request.url);
+        searchRequests.push(url);
+        const radius = url.searchParams.get("radius_km");
+        if (radius === "10") {
+          return HttpResponse.json(radiusTenResponse);
+        }
+        return HttpResponse.json(radiusFiveResponse);
+      }),
+    );
+
+    renderGymsPage();
+
+    expect(await screen.findByText("半径5kmトレーニングジム")).toBeInTheDocument();
+
+    const distanceSlider = screen.getByLabelText("検索半径（キロメートル）") as HTMLInputElement;
+    expect(distanceSlider).not.toBeDisabled();
+
+    await userEvent.click(distanceSlider);
+    fireEvent.change(distanceSlider, { target: { value: "10" } });
+
+    await screen.findByText("半径10kmフィットネスセンター");
+    expect(distanceSlider.value).toBe("10");
+    await waitFor(() => expect(screen.queryByText("半径5kmトレーニングジム")).not.toBeInTheDocument());
+
+    expect(searchRequests.some((url) => url.searchParams.get("radius_km") === "10")).toBe(true);
+    expect(searchRequests.at(-1)?.searchParams.get("radius_km")).toBe("10");
+  });
+});

--- a/frontend/tests/integration/Pagination.int.test.tsx
+++ b/frontend/tests/integration/Pagination.int.test.tsx
@@ -1,0 +1,300 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { vi } from "vitest";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
+import { server } from "../msw/server";
+import { GymsPage } from "@/features/gyms/GymsPage";
+import { Toaster } from "@/components/ui/toaster";
+
+class TestReadonlyURLSearchParams extends URLSearchParams {
+  append(): void {
+    throw new Error("append is not supported in tests");
+  }
+
+  delete(): void {
+    throw new Error("delete is not supported in tests");
+  }
+
+  set(): void {
+    throw new Error("set is not supported in tests");
+  }
+}
+
+const createSearchParams = (init: string = ""): ReadonlyURLSearchParams => {
+  return new TestReadonlyURLSearchParams(init) as unknown as ReadonlyURLSearchParams;
+};
+
+let mockSearchParams = createSearchParams();
+
+const updateSearchParamsFromUrl = (url: string) => {
+  const queryIndex = url.indexOf("?");
+  const query = queryIndex >= 0 ? url.slice(queryIndex + 1) : "";
+  mockSearchParams = createSearchParams(query);
+};
+
+const mockRouter = {
+  push: vi.fn((url: string) => {
+    updateSearchParamsFromUrl(url);
+  }),
+};
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+  usePathname: () => "/gyms",
+  useSearchParams: () => mockSearchParams,
+}));
+
+const renderGymsPage = () =>
+  render(
+    <>
+      <GymsPage />
+      <Toaster />
+    </>,
+  );
+
+const setSearchParams = (query: string) => {
+  mockSearchParams = createSearchParams(query);
+};
+
+type GeolocationMock = Pick<Geolocation, "getCurrentPosition" | "watchPosition" | "clearWatch">;
+
+const applyGeolocationMock = (mock: GeolocationMock) => {
+  Object.defineProperty(navigator, "geolocation", {
+    configurable: true,
+    value: mock as Geolocation,
+  });
+  return mock;
+};
+
+const createSuccessGeolocation = (lat: number, lng: number) => {
+  const mock: GeolocationMock = {
+    getCurrentPosition: vi.fn((success) => {
+      success({
+        coords: {
+          accuracy: 5,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          latitude: lat,
+          longitude: lng,
+          speed: null,
+        },
+        timestamp: Date.now(),
+      } as GeolocationPosition);
+    }),
+    watchPosition: vi.fn(),
+    clearWatch: vi.fn(),
+  };
+  return applyGeolocationMock(mock);
+};
+
+describe("Pagination integration", () => {
+  let originalGeolocation: Geolocation | undefined;
+
+  beforeEach(() => {
+    originalGeolocation = navigator.geolocation;
+    setSearchParams("");
+    mockRouter.push.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalGeolocation) {
+      Object.defineProperty(navigator, "geolocation", {
+        configurable: true,
+        value: originalGeolocation,
+      });
+    } else {
+      Object.defineProperty(navigator, "geolocation", {
+        configurable: true,
+        value: undefined,
+      });
+    }
+  });
+
+  it("loads the next page and updates the query parameters", async () => {
+    createSuccessGeolocation(35.68, 139.76);
+
+    const searchRequests: URL[] = [];
+    const pageOneResponse = {
+      items: [
+        {
+          id: 201,
+          slug: "page-one-alpha",
+          name: "ページ1・アルファジム",
+          city: "shinjuku",
+          pref: "tokyo",
+          equipments: ["パワーラック"],
+          thumbnail_url: null,
+          last_verified_at: "2024-02-01T09:00:00Z",
+        },
+        {
+          id: 202,
+          slug: "page-one-beta",
+          name: "ページ1・ベータジム",
+          city: "shibuya",
+          pref: "tokyo",
+          equipments: ["マシン"],
+          thumbnail_url: null,
+          last_verified_at: "2024-02-05T12:00:00Z",
+        },
+      ],
+      total: 4,
+      page: 1,
+      page_size: 2,
+      per_page: 2,
+      has_next: true,
+      has_prev: false,
+      has_more: true,
+      page_token: null,
+    };
+    const pageTwoResponse = {
+      items: [
+        {
+          id: 203,
+          slug: "page-two-gamma",
+          name: "ページ2・ガンマジム",
+          city: "chiyoda",
+          pref: "tokyo",
+          equipments: ["フリーウェイト"],
+          thumbnail_url: null,
+          last_verified_at: "2024-02-10T09:00:00Z",
+        },
+        {
+          id: 204,
+          slug: "page-two-delta",
+          name: "ページ2・デルタジム",
+          city: "meguro",
+          pref: "tokyo",
+          equipments: ["ストレッチ"],
+          thumbnail_url: null,
+          last_verified_at: "2024-02-12T09:00:00Z",
+        },
+      ],
+      total: 4,
+      page: 2,
+      page_size: 2,
+      per_page: 2,
+      has_next: false,
+      has_prev: true,
+      has_more: false,
+      page_token: null,
+    };
+
+    server.use(
+      http.get("*/gyms/search", ({ request }) => {
+        const url = new URL(request.url);
+        searchRequests.push(url);
+        const page = url.searchParams.get("page") ?? "1";
+        if (page === "2") {
+          return HttpResponse.json(pageTwoResponse);
+        }
+        return HttpResponse.json(pageOneResponse);
+      }),
+    );
+
+    renderGymsPage();
+
+    expect(await screen.findByText("ページ1・アルファジム")).toBeInTheDocument();
+    expect(screen.getByText("ページ1・ベータジム")).toBeInTheDocument();
+
+    const nextButton = screen.getByRole("button", { name: "次のページ" });
+    expect(nextButton).not.toBeDisabled();
+    await userEvent.click(nextButton);
+
+    await waitFor(() => expect(mockRouter.push).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(searchRequests.length).toBeGreaterThan(2));
+    await waitFor(() =>
+      expect(searchRequests.some((url) => url.searchParams.get("page") === "2")).toBe(true),
+    );
+
+    await screen.findByText("ページ2・ガンマジム");
+    expect(screen.getByText("ページ2・デルタジム")).toBeInTheDocument();
+    expect(await screen.findByText(/ページ 2/)).toBeInTheDocument();
+
+    expect(searchRequests.at(-1)?.searchParams.get("page")).toBe("2");
+  });
+
+  it("changes the page size when a new limit is selected", async () => {
+    createSuccessGeolocation(35.68, 139.76);
+
+    const searchRequests: URL[] = [];
+    const limitTwentyResponse = {
+      items: [
+        {
+          id: 301,
+          slug: "twenty-alpha",
+          name: "20件表示・アルファジム",
+          city: "shibuya",
+          pref: "tokyo",
+          equipments: ["パワーラック"],
+          thumbnail_url: null,
+          last_verified_at: "2024-01-15T09:00:00Z",
+        },
+      ],
+      total: 20,
+      page: 1,
+      page_size: 20,
+      per_page: 20,
+      has_next: true,
+      has_prev: false,
+      has_more: true,
+      page_token: null,
+    };
+    const limitTenResponse = {
+      items: [
+        {
+          id: 302,
+          slug: "ten-alpha",
+          name: "10件表示・アルファジム",
+          city: "setagaya",
+          pref: "tokyo",
+          equipments: ["ランニングマシン"],
+          thumbnail_url: null,
+          last_verified_at: "2024-01-20T09:00:00Z",
+        },
+      ],
+      total: 10,
+      page: 1,
+      page_size: 10,
+      per_page: 10,
+      has_next: true,
+      has_prev: false,
+      has_more: true,
+      page_token: null,
+    };
+
+    server.use(
+      http.get("*/gyms/search", ({ request }) => {
+        const url = new URL(request.url);
+        searchRequests.push(url);
+        const limit = url.searchParams.get("page_size") ?? url.searchParams.get("per_page");
+        if (limit === "10") {
+          return HttpResponse.json(limitTenResponse);
+        }
+        return HttpResponse.json(limitTwentyResponse);
+      }),
+    );
+
+    renderGymsPage();
+
+    expect(await screen.findByText("20件表示・アルファジム")).toBeInTheDocument();
+
+    const limitSelect = screen.getByLabelText("表示件数");
+    await userEvent.selectOptions(limitSelect, "10");
+
+    await screen.findByText("10件表示・アルファジム");
+    await waitFor(() => expect(screen.queryByText("20件表示・アルファジム")).not.toBeInTheDocument());
+
+    expect(
+      searchRequests.some((url) =>
+        url.searchParams.get("page_size") === "10" || url.searchParams.get("per_page") === "10",
+      ),
+    ).toBe(true);
+    const lastRequest = searchRequests.at(-1);
+    expect(
+      lastRequest?.searchParams.get("page_size") ?? lastRequest?.searchParams.get("per_page"),
+    ).toBe("10");
+  });
+});

--- a/frontend/tests/integration/SearchFlow.int.test.tsx
+++ b/frontend/tests/integration/SearchFlow.int.test.tsx
@@ -1,0 +1,300 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { vi } from "vitest";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
+import { server } from "../msw/server";
+import { defaultGymSearchResponse } from "../msw/handlers";
+import { GymsPage } from "@/features/gyms/GymsPage";
+import { Toaster } from "@/components/ui/toaster";
+import { FALLBACK_LOCATION } from "@/hooks/useGymSearch";
+
+class TestReadonlyURLSearchParams extends URLSearchParams {
+  append(): void {
+    throw new Error("append is not supported in tests");
+  }
+
+  delete(): void {
+    throw new Error("delete is not supported in tests");
+  }
+
+  set(): void {
+    throw new Error("set is not supported in tests");
+  }
+}
+
+const createSearchParams = (init: string = ""): ReadonlyURLSearchParams => {
+  return new TestReadonlyURLSearchParams(init) as unknown as ReadonlyURLSearchParams;
+};
+
+let mockSearchParams = createSearchParams();
+
+const updateSearchParamsFromUrl = (url: string) => {
+  const queryIndex = url.indexOf("?");
+  const query = queryIndex >= 0 ? url.slice(queryIndex + 1) : "";
+  mockSearchParams = createSearchParams(query);
+};
+
+const mockRouter = {
+  push: vi.fn((url: string) => {
+    updateSearchParamsFromUrl(url);
+  }),
+};
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+  usePathname: () => "/gyms",
+  useSearchParams: () => mockSearchParams,
+}));
+
+const renderGymsPage = () =>
+  render(
+    <>
+      <GymsPage />
+      <Toaster />
+    </>,
+  );
+
+const setSearchParams = (query: string) => {
+  mockSearchParams = createSearchParams(query);
+};
+
+type GeolocationMock = Pick<Geolocation, "getCurrentPosition" | "watchPosition" | "clearWatch">;
+
+const applyGeolocationMock = (mock: GeolocationMock) => {
+  Object.defineProperty(navigator, "geolocation", {
+    configurable: true,
+    value: mock as Geolocation,
+  });
+  return mock;
+};
+
+const createSuccessGeolocation = (lat: number, lng: number) => {
+  const mock: GeolocationMock = {
+    getCurrentPosition: vi.fn((success) => {
+      success({
+        coords: {
+          accuracy: 5,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          latitude: lat,
+          longitude: lng,
+          speed: null,
+        },
+        timestamp: Date.now(),
+      } as GeolocationPosition);
+    }),
+    watchPosition: vi.fn(),
+    clearWatch: vi.fn(),
+  };
+  return applyGeolocationMock(mock);
+};
+
+const createPermissionDeniedGeolocation = () => {
+  const error = {
+    code: 1,
+    PERMISSION_DENIED: 1,
+    POSITION_UNAVAILABLE: 2,
+    TIMEOUT: 3,
+    message: "Permission denied",
+  } as GeolocationPositionError;
+  const mock: GeolocationMock = {
+    getCurrentPosition: vi.fn((_, errorCallback) => {
+      errorCallback?.(error);
+    }),
+    watchPosition: vi.fn(),
+    clearWatch: vi.fn(),
+  };
+  return applyGeolocationMock(mock);
+};
+
+describe("Search flow integration", () => {
+  let originalGeolocation: Geolocation | undefined;
+
+  beforeEach(() => {
+    originalGeolocation = navigator.geolocation;
+    setSearchParams("");
+    mockRouter.push.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalGeolocation) {
+      Object.defineProperty(navigator, "geolocation", {
+        configurable: true,
+        value: originalGeolocation,
+      });
+    } else {
+      Object.defineProperty(navigator, "geolocation", {
+        configurable: true,
+        value: undefined,
+      });
+    }
+  });
+
+  it("performs a keyword search and renders the matching gyms", async () => {
+    createSuccessGeolocation(35.68, 139.76);
+
+    const searchRequests: URL[] = [];
+    const keywordResponse = {
+      items: [
+        {
+          id: 10,
+          slug: "powerhouse",
+          name: "パワーハウスジム",
+          city: "meguro",
+          pref: "tokyo",
+          equipments: ["パワーラック"],
+          thumbnail_url: null,
+          last_verified_at: "2024-04-12T10:00:00Z",
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      per_page: 20,
+      has_next: false,
+      has_prev: false,
+      has_more: false,
+      page_token: null,
+    };
+
+    server.use(
+      http.get("*/gyms/search", ({ request }) => {
+        const url = new URL(request.url);
+        searchRequests.push(url);
+        const keyword = url.searchParams.get("q");
+        if (keyword && keyword.toLowerCase().includes("power")) {
+          return HttpResponse.json(keywordResponse);
+        }
+        return HttpResponse.json(defaultGymSearchResponse);
+      }),
+    );
+
+    renderGymsPage();
+
+    expect(await screen.findByText("東京フィットジム")).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    const keywordInput = screen.getByLabelText("キーワード");
+    await user.clear(keywordInput);
+    await user.type(keywordInput, "power");
+
+    await screen.findByText("パワーハウスジム");
+    await waitFor(() => expect(screen.queryByText("東京フィットジム")).not.toBeInTheDocument());
+
+    expect(
+      searchRequests.some((url) => url.searchParams.get("q")?.toLowerCase() === "power"),
+    ).toBe(true);
+  });
+
+  it("requests the current position and includes coordinates in the search query", async () => {
+    const geolocation = createSuccessGeolocation(35.68, 139.76);
+
+    const searchRequests: URL[] = [];
+    const nearbyResponse = {
+      items: [
+        {
+          id: 20,
+          slug: "nearby-fitness",
+          name: "現在地フィットネス",
+          city: "chiyoda",
+          pref: "tokyo",
+          equipments: ["ランニングマシン"],
+          thumbnail_url: null,
+          last_verified_at: "2024-05-01T08:00:00Z",
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      per_page: 20,
+      has_next: false,
+      has_prev: false,
+      has_more: false,
+      page_token: null,
+    };
+
+    server.use(
+      http.get("*/gyms/search", ({ request }) => {
+        const url = new URL(request.url);
+        searchRequests.push(url);
+        if (url.searchParams.has("lat")) {
+          return HttpResponse.json(nearbyResponse);
+        }
+        return HttpResponse.json(defaultGymSearchResponse);
+      }),
+    );
+
+    renderGymsPage();
+
+    expect(geolocation.getCurrentPosition).toHaveBeenCalled();
+
+    await screen.findByText("現在地フィットネス");
+
+    expect(
+      searchRequests.some((url) =>
+        url.searchParams.get("lat") === "35.68" && url.searchParams.get("lng") === "139.76",
+      ),
+    ).toBe(true);
+    expect(await screen.findByText(/現在地を使用中/)).toBeInTheDocument();
+  });
+
+  it("falls back to the default location when geolocation is denied", async () => {
+    const geolocation = createPermissionDeniedGeolocation();
+
+    const searchRequests: URL[] = [];
+    const fallbackResponse = {
+      items: [
+        {
+          id: 30,
+          slug: "tokyo-station-gym",
+          name: "東京駅トレーニングセンター",
+          city: "chiyoda",
+          pref: "tokyo",
+          equipments: ["マシン", "ストレッチ"],
+          thumbnail_url: null,
+          last_verified_at: "2024-05-20T09:00:00Z",
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      per_page: 20,
+      has_next: false,
+      has_prev: false,
+      has_more: false,
+      page_token: null,
+    };
+
+    server.use(
+      http.get("*/gyms/search", ({ request }) => {
+        const url = new URL(request.url);
+        searchRequests.push(url);
+        if (
+          url.searchParams.get("lat") === FALLBACK_LOCATION.lat.toString() &&
+          url.searchParams.get("lng") === FALLBACK_LOCATION.lng.toString()
+        ) {
+          return HttpResponse.json(fallbackResponse);
+        }
+        return HttpResponse.json(defaultGymSearchResponse);
+      }),
+    );
+
+    renderGymsPage();
+
+    expect(geolocation.getCurrentPosition).toHaveBeenCalled();
+
+    await screen.findByText("東京駅トレーニングセンター");
+
+    expect(
+      searchRequests.some((url) =>
+        url.searchParams.get("lat") === FALLBACK_LOCATION.lat.toString() &&
+        url.searchParams.get("lng") === FALLBACK_LOCATION.lng.toString(),
+      ),
+    ).toBe(true);
+
+    expect(await screen.findByText(/デフォルト地点（東京駅）を使用中/)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/msw/handlers.ts
+++ b/frontend/tests/msw/handlers.ts
@@ -1,0 +1,58 @@
+import { http, HttpResponse } from "msw";
+
+const prefectureSlugs = ["tokyo", "kanagawa"];
+const equipmentCategories = ["フリーウェイト", "マシン", "カーディオ"];
+
+const tokyoCities = [
+  { city: "shinjuku", count: 12 },
+  { city: "shibuya", count: 9 },
+  { city: "meguro", count: 5 },
+];
+
+export const defaultGymSearchResponse = {
+  items: [
+    {
+      id: 1,
+      slug: "tokyo-fit",
+      name: "東京フィットジム",
+      city: "shinjuku",
+      pref: "tokyo",
+      equipments: ["ダンベル", "パワーラック"],
+      thumbnail_url: null,
+      last_verified_at: "2024-02-10T09:00:00Z",
+    },
+    {
+      id: 2,
+      slug: "shibuya-strength",
+      name: "渋谷ストレングス",
+      city: "shibuya",
+      pref: "tokyo",
+      equipments: ["マシン", "フリーウェイト"],
+      thumbnail_url: null,
+      last_verified_at: "2024-03-05T15:30:00Z",
+    },
+  ],
+  total: 2,
+  page: 1,
+  page_size: 20,
+  per_page: 20,
+  has_next: false,
+  has_prev: false,
+  has_more: false,
+  page_token: null,
+};
+
+export const handlers = [
+  http.get("*/meta/prefectures", () => HttpResponse.json(prefectureSlugs)),
+  http.get("*/meta/equipment-categories", () => HttpResponse.json(equipmentCategories)),
+  http.get("*/meta/cities", ({ request }) => {
+    const url = new URL(request.url);
+    const pref = url.searchParams.get("pref");
+    if (pref === "tokyo") {
+      return HttpResponse.json(tokyoCities);
+    }
+    return HttpResponse.json([]);
+  }),
+  http.get("*/suggest/gyms", () => HttpResponse.json([])),
+  http.get("*/gyms/search", () => HttpResponse.json(defaultGymSearchResponse)),
+];

--- a/frontend/tests/msw/server.ts
+++ b/frontend/tests/msw/server.ts
@@ -1,0 +1,5 @@
+import { setupServer } from "msw/node";
+
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,13 +1,30 @@
-import { afterEach, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { server } from "./tests/msw/server";
 
 const defaultApiBase = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8000";
 process.env.NEXT_PUBLIC_API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? defaultApiBase;
 process.env.NEXT_PUBLIC_API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? defaultApiBase;
 process.env.NEXT_PUBLIC_AUTH_MODE = process.env.NEXT_PUBLIC_AUTH_MODE ?? "stub";
 
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+});
+
 afterEach(() => {
+  server.resetHandlers();
   cleanup();
   vi.clearAllMocks();
 });
+
+afterAll(() => {
+  server.close();
+});
+
+if (!HTMLElement.prototype.scrollIntoView) {
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "scripts": {
     "lint": "npm run lint --prefix frontend",
     "typecheck": "npm run typecheck --prefix frontend",
-    "test:unit": "npm run test:unit --prefix frontend"
+    "test:unit": "npm run test:unit --prefix frontend",
+    "test:integration": "npm run test:integration --prefix frontend",
+    "test:ci": "npm run lint && npm run typecheck && npm run test:unit && npm run test:integration"
   }
 }


### PR DESCRIPTION
## 目的
- 検索フローの回帰を軽量に検出

## 変更
- MSW導入、統合テスト3〜6本、CIにintegration少数追加

## 確認
- PRのCIは全てグリーン、ローカル npm run test:integration も成功

------
https://chatgpt.com/codex/tasks/task_e_68d39470112c832a8e251ef8d27e019c