### PR TITLE
【FE-3】検索UIのUX/A11y改善（スケルトン/空状態/エラー/軽量テスト）

### DIFF
--- a/frontend/src/components/common/SearchBar.tsx
+++ b/frontend/src/components/common/SearchBar.tsx
@@ -11,6 +11,7 @@ export interface SearchBarProps {
   className?: string;
   inputClassName?: string;
   inputProps?: Omit<InputHTMLAttributes<HTMLInputElement>, "id" | "value" | "onChange">;
+  inputRef?: React.Ref<HTMLInputElement>;
   children?: ReactNode;
 }
 
@@ -23,6 +24,7 @@ export function SearchBar({
   className,
   inputClassName,
   inputProps,
+  inputRef,
   children,
 }: SearchBarProps) {
   return (
@@ -40,6 +42,7 @@ export function SearchBar({
             inputClassName,
           )}
           id={id}
+          ref={inputRef}
           onChange={(event) => onChange(event.target.value)}
           placeholder={placeholder}
           type={inputProps?.type ?? "search"}

--- a/frontend/src/components/search/SearchDistanceBadge.tsx
+++ b/frontend/src/components/search/SearchDistanceBadge.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+
+type SearchDistanceBadgeProps = {
+  distanceKm: number;
+  className?: string;
+};
+
+export function SearchDistanceBadge({ distanceKm, className }: SearchDistanceBadgeProps) {
+  return (
+    <span
+      aria-live="polite"
+      className={cn(
+        "inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5",
+        "text-xs font-medium text-primary",
+        className,
+      )}
+    >
+      半径: 約 {distanceKm}km
+    </span>
+  );
+}

--- a/frontend/src/components/search/SearchEmpty.tsx
+++ b/frontend/src/components/search/SearchEmpty.tsx
@@ -1,0 +1,43 @@
+import { Compass } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type SearchEmptyProps = {
+  onResetFilters?: () => void;
+  className?: string;
+};
+
+export function SearchEmpty({ onResetFilters, className }: SearchEmptyProps) {
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "flex flex-col items-center gap-4 rounded-lg border border-dashed",
+        "border-muted-foreground/40 bg-muted/20 p-8 text-center",
+        className,
+      )}
+      role="status"
+    >
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-background shadow">
+        <Compass aria-hidden="true" className="h-7 w-7 text-muted-foreground" />
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold">該当するジムが見つかりませんでした</h3>
+        <p className="text-sm text-muted-foreground">
+          条件を少し緩めるか、別のキーワードでお試しください。
+        </p>
+      </div>
+      <ul className="list-disc space-y-1 text-left text-sm text-muted-foreground">
+        <li>キーワードを短くするか、別の言葉を試す</li>
+        <li>距離やカテゴリの条件を広げて再検索する</li>
+        <li>都道府県・市区町村の指定を解除する</li>
+      </ul>
+      {onResetFilters ? (
+        <Button onClick={onResetFilters} type="button" variant="outline">
+          条件をクリア
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/search/SearchError.tsx
+++ b/frontend/src/components/search/SearchError.tsx
@@ -1,0 +1,33 @@
+import { AlertCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type SearchErrorProps = {
+  message?: string | null;
+  onRetry: () => void;
+  className?: string;
+};
+
+const DEFAULT_ERROR_MESSAGE = "ジムの取得に失敗しました";
+
+export function SearchError({ message, onRetry, className }: SearchErrorProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center gap-4 rounded-lg border border-destructive/40",
+        "bg-destructive/10 p-6 text-center text-sm text-destructive",
+        className,
+      )}
+      role="alert"
+    >
+      <div className="flex items-start gap-2">
+        <AlertCircle aria-hidden="true" className="mt-0.5 h-5 w-5" />
+        <p className="text-left">{message || DEFAULT_ERROR_MESSAGE}</p>
+      </div>
+      <Button onClick={onRetry} type="button" variant="outline">
+        再試行
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/search/SearchSkeleton.tsx
+++ b/frontend/src/components/search/SearchSkeleton.tsx
@@ -1,0 +1,41 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+type SearchSkeletonProps = {
+  count?: number;
+  className?: string;
+};
+
+const DEFAULT_SKELETON_COUNT = 6;
+
+export function SearchSkeleton({ count = DEFAULT_SKELETON_COUNT, className }: SearchSkeletonProps) {
+  const items = Array.from({ length: Math.max(count, DEFAULT_SKELETON_COUNT) });
+
+  return (
+    <div aria-live="polite" className="space-y-2">
+      <span className="sr-only" role="status">
+        検索結果を読み込み中です…
+      </span>
+      <div
+        aria-hidden="true"
+        className={cn("grid gap-4 sm:grid-cols-2 xl:grid-cols-3", className)}
+      >
+        {items.map((_, index) => (
+          <Card data-testid="search-result-skeleton" key={index} className="overflow-hidden">
+            <Skeleton className="h-40 w-full" />
+            <CardContent className="space-y-3">
+              <Skeleton className="h-6 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+              <div className="flex gap-2">
+                <Skeleton className="h-6 w-16 rounded-full" />
+                <Skeleton className="h-6 w-16 rounded-full" />
+                <Skeleton className="h-6 w-16 rounded-full" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/search/useSearchResultState.ts
+++ b/frontend/src/components/search/useSearchResultState.ts
@@ -1,0 +1,57 @@
+import { useMemo } from "react";
+
+import type { GymSummary } from "@/types/gym";
+
+export type SearchResultStatus = "loading" | "error" | "empty" | "success";
+
+type UseSearchResultStateOptions = {
+  isLoading: boolean;
+  error: string | null;
+  items: GymSummary[];
+};
+
+export function useSearchResultState({
+  isLoading,
+  error,
+  items,
+}: UseSearchResultStateOptions) {
+  return useMemo(() => {
+    if (error) {
+      return {
+        status: "error" as SearchResultStatus,
+        isError: true,
+        isLoading: false,
+        isEmpty: false,
+        isSuccess: false,
+      };
+    }
+
+    if (isLoading) {
+      return {
+        status: "loading" as SearchResultStatus,
+        isError: false,
+        isLoading: true,
+        isEmpty: false,
+        isSuccess: false,
+      };
+    }
+
+    if (items.length === 0) {
+      return {
+        status: "empty" as SearchResultStatus,
+        isError: false,
+        isLoading: false,
+        isEmpty: true,
+        isSuccess: false,
+      };
+    }
+
+    return {
+      status: "success" as SearchResultStatus,
+      isError: false,
+      isLoading: false,
+      isEmpty: false,
+      isSuccess: true,
+    };
+  }, [error, isLoading, items.length]);
+}

--- a/frontend/src/features/gyms/GymsPage.tsx
+++ b/frontend/src/features/gyms/GymsPage.tsx
@@ -14,6 +14,7 @@ export function GymsPage() {
     updateSort,
     updateDistance,
     clearFilters,
+    submitSearch,
     location,
     requestLocation,
     clearLocation,
@@ -58,6 +59,7 @@ export function GymsPage() {
             isCityLoading={isCityLoading}
             isMetaLoading={isMetaLoading}
             metaError={metaError}
+            isSearchLoading={isLoading}
             onCategoriesChange={updateCategories}
             onCityChange={updateCity}
             onClear={clearFilters}
@@ -71,6 +73,7 @@ export function GymsPage() {
             onReloadCities={reloadCities}
             onReloadMeta={reloadMeta}
             onSortChange={updateSort}
+            onSubmitSearch={submitSearch}
             location={location}
             prefectures={prefectures}
             state={formState}
@@ -82,6 +85,7 @@ export function GymsPage() {
             isLoading={isLoading}
             limit={limit}
             meta={meta}
+            onClearFilters={clearFilters}
             onLimitChange={setLimit}
             onPageChange={setPage}
             onRetry={retry}

--- a/frontend/src/features/gyms/__tests__/GymsPage.test.tsx
+++ b/frontend/src/features/gyms/__tests__/GymsPage.test.tsx
@@ -46,6 +46,7 @@ const buildHookState = (overrides: Partial<UseGymSearchResult> = {}): UseGymSear
     updateSort: vi.fn(),
     updateDistance: vi.fn(),
     clearFilters: vi.fn(),
+    submitSearch: vi.fn(),
     location: {
       lat: null,
       lng: null,
@@ -212,5 +213,17 @@ describe("GymsPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "条件をクリア" }));
 
     expect(clearFilters).toHaveBeenCalled();
+  });
+
+  it("submits the search when the search button is pressed", async () => {
+    const submitSearch = vi.fn();
+    mockedUseGymSearch.mockReturnValue(buildHookState({ submitSearch }));
+
+    render(<GymsPage />);
+
+    const [searchButton] = screen.getAllByRole("button", { name: "検索を実行" });
+    await userEvent.click(searchButton);
+
+    expect(submitSearch).toHaveBeenCalled();
   });
 });

--- a/frontend/tests/integration/Pagination.int.test.tsx
+++ b/frontend/tests/integration/Pagination.int.test.tsx
@@ -211,7 +211,8 @@ describe("Pagination integration", () => {
 
     await screen.findByText("ページ2・ガンマジム");
     expect(screen.getByText("ページ2・デルタジム")).toBeInTheDocument();
-    expect(await screen.findByText(/ページ 2/)).toBeInTheDocument();
+    const currentPageButton = await screen.findByRole("button", { name: "ページ 2" });
+    expect(currentPageButton).toHaveAttribute("aria-current", "page");
 
     expect(searchRequests.at(-1)?.searchParams.get("page")).toBe("2");
   });


### PR DESCRIPTION
## Summary
- add dedicated search UI state components (skeleton, empty, error, distance badge) and wire them into GymList with the existing pagination component
- expose a submitSearch helper from useGymSearch and surface a loading-aware submit button plus improved location error guidance and distance badge in SearchFilters
- refresh integration coverage for loading/empty/error/location flows and update unit tests to reflect the new search controls

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68d3b101a1d4832abbdb311f306eff2b