### PR TITLE
feat(frontend): 検索UIのモバイル最適化・アクセシビリティ改善（StepFE-4）

### DIFF
--- a/frontend/app/gyms/_components/GymsPageFallback.tsx
+++ b/frontend/app/gyms/_components/GymsPageFallback.tsx
@@ -1,38 +1,50 @@
 export function GymsPageFallback() {
   return (
-    <div className="flex min-h-screen flex-col gap-6 px-4 py-10">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
-        <div className="space-y-3">
-          <div className="h-4 w-28 animate-pulse rounded bg-muted" />
-          <div className="h-8 w-44 animate-pulse rounded bg-muted" />
-          <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+    <div className="flex min-h-screen w-full flex-col bg-muted/10">
+      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-4 pb-16 pt-8 sm:gap-10 sm:pt-12 lg:px-6 xl:px-0">
+        <div className="space-y-3 sm:space-y-4">
+          <div className="h-3.5 w-24 animate-pulse rounded-full bg-muted" />
+          <div className="h-8 w-48 animate-pulse rounded-full bg-muted" />
+          <div className="h-4 w-3/4 animate-pulse rounded-full bg-muted" />
         </div>
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-          <div className="space-y-6">
-            <div className="grid gap-4 rounded-lg border bg-card p-6 shadow-sm">
-              <div className="h-10 w-full animate-pulse rounded bg-muted" />
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="h-10 w-full animate-pulse rounded bg-muted" />
-                <div className="h-10 w-full animate-pulse rounded bg-muted" />
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,360px)_minmax(0,1fr)] lg:items-start xl:grid-cols-[minmax(0,380px)_minmax(0,1fr)] xl:gap-8">
+          <div className="space-y-4">
+            <div className="flex flex-col gap-4 rounded-2xl border border-border/80 bg-card/95 p-6 shadow-sm sm:p-7">
+              <div className="h-10 w-full animate-pulse rounded-md bg-muted" />
+              <div className="h-10 w-full animate-pulse rounded-md bg-muted" />
+              <div className="h-20 w-full animate-pulse rounded-xl bg-muted/70" />
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="h-10 w-full animate-pulse rounded-md bg-muted" />
+                <div className="h-10 w-full animate-pulse rounded-md bg-muted" />
               </div>
+              <div className="h-32 w-full animate-pulse rounded-xl border border-dashed border-muted-foreground/30 bg-muted/40" />
             </div>
-            <div className="grid gap-4 rounded-lg border bg-card p-6 shadow-sm">
-              <div className="h-6 w-36 animate-pulse rounded bg-muted" />
-              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <div className="rounded-2xl border border-border/80 bg-card/95 p-6 shadow-sm sm:p-7">
+              <div className="h-6 w-32 animate-pulse rounded bg-muted" />
+              <div className="mt-4 h-10 w-full animate-pulse rounded bg-muted" />
+            </div>
+          </div>
+          <div className="space-y-6">
+            <div className="rounded-2xl border border-border/80 bg-card/95 p-6 shadow-sm sm:p-8">
+              <div className="h-6 w-28 animate-pulse rounded bg-muted" />
+              <div className="mt-6 grid gap-4 sm:grid-cols-2 sm:gap-6 xl:grid-cols-3 xl:gap-7">
                 {Array.from({ length: 6 }).map((_, index) => (
-                  <div key={index} className="space-y-3 rounded-lg border p-4">
-                    <div className="h-24 w-full animate-pulse rounded bg-muted" />
+                  <div
+                    key={index}
+                    className="space-y-3 rounded-xl border border-border/70 bg-background/80 p-4"
+                  >
+                    <div className="h-28 w-full animate-pulse rounded-lg bg-muted" />
                     <div className="h-5 w-3/4 animate-pulse rounded bg-muted" />
                     <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
                   </div>
                 ))}
               </div>
             </div>
-          </div>
-          <div className="space-y-4">
-            <div className="rounded-lg border bg-card p-6 shadow-sm">
-              <div className="h-6 w-32 animate-pulse rounded bg-muted" />
-              <div className="mt-4 h-10 w-full animate-pulse rounded bg-muted" />
+            <div className="rounded-2xl border border-border/80 bg-card/95 p-6 shadow-sm sm:p-8">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+                <div className="h-9 w-36 animate-pulse rounded bg-muted" />
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/gyms/GymCard.tsx
+++ b/frontend/src/components/gyms/GymCard.tsx
@@ -18,13 +18,13 @@ export function GymCard({ gym, className }: GymCardProps) {
       )}
       href={`/gyms/${gym.slug}`}
     >
-      <Card className="flex h-full flex-col overflow-hidden transition group-hover:border-primary">
-        <div className="flex h-40 items-center justify-center bg-muted text-sm text-muted-foreground">
+      <Card className="flex h-full flex-col overflow-hidden rounded-2xl border-border/70 transition group-hover:border-primary">
+        <div className="flex h-44 items-center justify-center bg-muted text-sm text-muted-foreground">
           {gym.thumbnailUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
               alt={gym.name}
-              className="h-full w-full object-cover transition group-hover:scale-[1.02]"
+              className="h-full w-full object-cover transition group-hover:scale-[1.03]"
               src={gym.thumbnailUrl}
             />
           ) : (
@@ -32,7 +32,9 @@ export function GymCard({ gym, className }: GymCardProps) {
           )}
         </div>
         <CardHeader className="space-y-2">
-          <CardTitle className="text-xl group-hover:text-primary">{gym.name}</CardTitle>
+          <CardTitle className="text-lg font-semibold leading-snug group-hover:text-primary sm:text-xl">
+            {gym.name}
+          </CardTitle>
           <CardDescription className="text-sm text-muted-foreground">
             {gym.prefecture ? gym.prefecture : "エリア未設定"}
             {gym.city ? ` / ${gym.city}` : null}
@@ -44,7 +46,7 @@ export function GymCard({ gym, className }: GymCardProps) {
               {gym.equipments.slice(0, 6).map((equipment) => (
                 <span
                   key={equipment}
-                  className="rounded-full bg-secondary px-2 py-1 text-xs text-secondary-foreground"
+                  className="rounded-full bg-secondary px-2.5 py-1 text-xs text-secondary-foreground"
                 >
                   {equipment}
                 </span>

--- a/frontend/src/components/gyms/GymList.tsx
+++ b/frontend/src/components/gyms/GymList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useId, useRef, type ReactNode } from "react";
 
 import { GymCard } from "@/components/gyms/GymCard";
 import { Pagination } from "@/components/gyms/Pagination";
@@ -72,6 +72,8 @@ export function GymList({
 
   const resultSectionRef = useRef<HTMLElement | null>(null);
   const previousPageRef = useRef(page);
+  const headerDescriptionId = useId();
+  const paginationSummaryId = useId();
 
   useEffect(() => {
     if (previousPageRef.current !== page && resultSectionRef.current) {
@@ -94,7 +96,15 @@ export function GymList({
       break;
     default:
       content = (
-        <div className={cn("grid gap-4", "sm:grid-cols-2", "xl:grid-cols-3")}>
+        <div
+          className={cn(
+            "grid gap-4",
+            "sm:grid-cols-2 sm:gap-6",
+            "lg:grid-cols-2",
+            "xl:grid-cols-3 xl:gap-7",
+            "2xl:grid-cols-4",
+          )}
+        >
           {gyms.map((gym) => (
             <GymCard key={gym.id} gym={gym} />
           ))}
@@ -130,30 +140,39 @@ export function GymList({
   return (
     <section
       aria-busy={resultState.isLoading}
+      aria-describedby={headerDescriptionId}
       aria-labelledby="gym-search-results-heading"
       aria-live="polite"
-      className="rounded-lg border bg-background p-6 shadow-sm"
+      className="rounded-2xl border border-border/80 bg-card/95 p-6 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/80 sm:p-8"
       ref={resultSectionRef}
       tabIndex={-1}
     >
-      <div className="flex flex-wrap items-center justify-between gap-4 pb-4">
-        <div>
-          <h2 className="text-xl font-semibold" id="gym-search-results-heading">
+      <div className="flex flex-col gap-4 pb-6 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
+        <div className="space-y-1.5">
+          <h2 className="text-2xl font-semibold tracking-tight" id="gym-search-results-heading">
             検索結果
           </h2>
-          <p className="text-sm text-muted-foreground">{headerDescription}</p>
+          <p className="text-sm leading-relaxed text-muted-foreground" id={headerDescriptionId}>
+            {headerDescription}
+          </p>
         </div>
+        {resultState.isSuccess ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{totalLabel}</span>
+            <span className="hidden sm:inline">が見つかりました</span>
+          </div>
+        ) : null}
       </div>
 
       {content}
 
       {showPagination ? (
-        <div className="mt-8 border-t pt-4">
+        <div className="mt-10 border-t border-border/70 pt-6">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <p aria-live="polite" className="text-sm text-muted-foreground">
+            <p aria-live="polite" className="text-sm text-muted-foreground" id={paginationSummaryId}>
               {paginationSummary}
             </p>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
               <div className="flex items-center gap-2">
                 <label className="text-sm text-muted-foreground" htmlFor="gym-search-limit">
                   表示件数
@@ -181,6 +200,7 @@ export function GymList({
                 </select>
               </div>
               <Pagination
+                ariaDescribedBy={paginationSummaryId}
                 currentPage={currentPage}
                 totalPages={paginationTotalPages}
                 hasNextPage={hasMore}

--- a/frontend/src/components/gyms/Pagination.tsx
+++ b/frontend/src/components/gyms/Pagination.tsx
@@ -13,6 +13,7 @@ type PaginationProps = {
   onChange: (page: number) => void;
   isLoading?: boolean;
   siblingCount?: number;
+  ariaDescribedBy?: string;
 };
 
 const range = (start: number, end: number): number[] =>
@@ -63,6 +64,7 @@ export function Pagination({
   onChange,
   isLoading = false,
   siblingCount = 1,
+  ariaDescribedBy,
 }: PaginationProps) {
   const paginationRange = useMemo(
     () => buildPaginationRange(currentPage, totalPages, siblingCount),
@@ -83,9 +85,15 @@ export function Pagination({
   const isPrevDisabled = isLoading || currentPage <= 1;
   const isNextDisabled = isLoading || (!hasNextPage && currentPage >= totalPages);
 
+  const mobileSummary = totalPages > 0 ? `${currentPage} / ${totalPages}` : `${currentPage}ページ目`;
+
   return (
-    <nav aria-label="ページネーション" className="flex justify-center">
-      <div className="flex flex-wrap items-center gap-2">
+    <nav
+      aria-describedby={ariaDescribedBy}
+      aria-label="ページネーション"
+      className="flex justify-center"
+    >
+      <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-3">
         <Button
           aria-label="前のページ"
           disabled={isPrevDisabled}
@@ -95,7 +103,10 @@ export function Pagination({
         >
           前へ
         </Button>
-        <ul className="flex items-center gap-1">
+        <span className="text-sm font-medium text-muted-foreground sm:hidden">
+          {mobileSummary}
+        </span>
+        <ul className="hidden items-center gap-1 sm:flex">
           {paginationRange.map((item, index) => {
             if (item === ELLIPSIS) {
               return (

--- a/frontend/src/components/gyms/SearchFilters.tsx
+++ b/frontend/src/components/gyms/SearchFilters.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
 
 import { SearchBar } from "@/components/common/SearchBar";
@@ -38,6 +38,8 @@ const SORT_SELECT_OPTIONS: Array<{
   { value: "rating:desc", sort: "rating", order: "desc", label: "評価（高い順）" },
   { value: "reviews:desc", sort: "reviews", order: "desc", label: "口コミ数（多い順）" },
 ];
+
+const DISTANCE_PRESET_OPTIONS = [1, 3, 5, 10, 15, 20, 25, 30];
 
 type SearchFiltersProps = {
   state: {
@@ -112,6 +114,12 @@ export function SearchFilters({
   const { toast } = useToast();
   const keywordInputRef = useRef<HTMLInputElement | null>(null);
   const lastLocationToastRef = useRef<string | null>(null);
+  const locationSummaryId = useId();
+  const manualLocationHintId = useId();
+  const manualLocationErrorId = useId();
+  const distanceHelpTextId = useId();
+  const prefectureHelpTextId = useId();
+  const cityHelpTextId = useId();
 
   useEffect(() => {
     if (location.lat != null) {
@@ -231,6 +239,13 @@ export function SearchFilters({
     () => [...cities].sort((a, b) => a.label.localeCompare(b.label, "ja")),
     [cities],
   );
+  const distanceOptions = useMemo(
+    () =>
+      Array.from(new Set([...DISTANCE_PRESET_OPTIONS, state.distance]))
+        .filter((value) => value >= MIN_DISTANCE_KM && value <= MAX_DISTANCE_KM)
+        .sort((a, b) => a - b),
+    [state.distance],
+  );
 
   const hasLocation = location.lat != null && location.lng != null;
   const isLocating = location.status === "loading";
@@ -294,72 +309,80 @@ export function SearchFilters({
     onClearLocation();
   };
 
+  const manualLocationDescriptionIds = manualError
+    ? `${manualLocationHintId} ${manualLocationErrorId}`
+    : manualLocationHintId;
+
   return (
-    <aside className="space-y-4">
+    <aside className="space-y-4 lg:sticky lg:top-28 lg:max-h-[calc(100vh-7rem)] lg:space-y-6 lg:overflow-y-auto lg:pr-2">
       <form
-        className="space-y-6 rounded-lg border bg-card p-6 shadow-sm"
+        className="flex flex-col gap-6 rounded-2xl border border-border/80 bg-card/95 p-6 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/80 sm:p-7"
         onSubmit={(event) => {
           event.preventDefault();
           onSubmitSearch();
         }}
       >
-        <SearchBar
-          id="gym-search-keyword"
-          inputProps={{ name: "keyword" }}
-          inputRef={keywordInputRef}
-          label="キーワード"
-          onChange={onKeywordChange}
-          placeholder="設備やジム名で検索"
-          value={state.q}
-        >
-          {state.q.trim().length >= 2 ? (
-            <div className="space-y-1">
-              {isSuggestLoading ? (
-                <p className="text-xs text-muted-foreground">候補を検索中です…</p>
-              ) : null}
-              {suggestError ? (
-                <p className="text-xs text-destructive">{suggestError}</p>
-              ) : null}
-              {suggestions.length > 0 ? (
-                <ul className="divide-y overflow-hidden rounded-md border bg-background text-sm">
-                  {suggestions.map((item) => (
-                    <li key={item.slug}>
-                      <button
-                        className={cn(
-                          "flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left",
-                          "transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                        )}
-                        onClick={() => handleSuggestionSelect(item)}
-                        type="button"
-                      >
-                        <span className="font-medium">{item.name}</span>
-                        <span className="text-xs text-muted-foreground">
-                          {[item.pref, item.city].filter(Boolean).join(" / ") || "地域情報なし"}
-                        </span>
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              ) : null}
-            </div>
-          ) : null}
-        </SearchBar>
-
-        <div className="flex justify-end">
-          <Button
-            aria-label="検索を実行"
-            disabled={isSearchLoading}
-            type="submit"
+        <div className="sticky top-[5.5rem] z-10 -mx-6 -mt-6 space-y-4 rounded-t-2xl border-b border-border/60 bg-card/95 px-6 pb-4 pt-6 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/80 sm:static sm:-mx-0 sm:-mt-0 sm:space-y-6 sm:border-none sm:bg-transparent sm:px-0 sm:py-0 sm:shadow-none">
+          <SearchBar
+            id="gym-search-keyword"
+            inputProps={{ name: "keyword" }}
+            inputRef={keywordInputRef}
+            label="キーワード"
+            onChange={onKeywordChange}
+            placeholder="設備やジム名で検索"
+            value={state.q}
           >
-            {isSearchLoading ? (
-              <span className="flex items-center gap-2">
-                <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
-                検索中…
-              </span>
-            ) : (
-              "検索"
-            )}
-          </Button>
+            {state.q.trim().length >= 2 ? (
+              <div className="space-y-1">
+                {isSuggestLoading ? (
+                  <p className="text-xs text-muted-foreground">候補を検索中です…</p>
+                ) : null}
+                {suggestError ? (
+                  <p className="text-xs text-destructive">{suggestError}</p>
+                ) : null}
+                {suggestions.length > 0 ? (
+                  <ul className="divide-y overflow-hidden rounded-md border bg-background text-sm shadow-sm">
+                    {suggestions.map((item) => (
+                      <li key={item.slug}>
+                        <button
+                          className={cn(
+                            "flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left",
+                            "transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          )}
+                          onClick={() => handleSuggestionSelect(item)}
+                          type="button"
+                        >
+                          <span className="font-medium">{item.name}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {[item.pref, item.city].filter(Boolean).join(" / ") || "地域情報なし"}
+                          </span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+            ) : null}
+          </SearchBar>
+          <div className="flex flex-wrap items-center justify-end gap-3">
+            <Button
+              aria-label="検索を実行"
+              disabled={isSearchLoading}
+              type="submit"
+            >
+              {isSearchLoading ? (
+                <span className="flex items-center gap-2">
+                  <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+                  検索中…
+                </span>
+              ) : (
+                "検索"
+              )}
+            </Button>
+            <Button onClick={onClear} type="button" variant="outline">
+              条件をクリア
+            </Button>
+          </div>
         </div>
 
         <div className="grid gap-2">
@@ -376,6 +399,7 @@ export function SearchFilters({
             name="prefecture"
             onChange={(event) => onPrefectureChange(event.target.value)}
             value={state.prefecture}
+            aria-describedby={prefectureHelpTextId}
           >
             <option value="">指定しない</option>
             {sortedPrefectures.map((prefecture) => (
@@ -384,6 +408,9 @@ export function SearchFilters({
               </option>
             ))}
           </select>
+          <p className="text-xs text-muted-foreground" id={prefectureHelpTextId}>
+            未選択の場合は全国から検索します。
+          </p>
         </div>
 
         <div className="grid gap-2">
@@ -400,6 +427,7 @@ export function SearchFilters({
             name="city"
             onChange={(event) => onCityChange(event.target.value)}
             value={state.city}
+            aria-describedby={cityHelpTextId}
           >
             <option value="">指定しない</option>
             {sortedCities.map((city) => (
@@ -408,7 +436,7 @@ export function SearchFilters({
               </option>
             ))}
           </select>
-          <p className="text-xs text-muted-foreground">
+          <p className="text-xs text-muted-foreground" id={cityHelpTextId}>
             都道府県を選択すると市区町村を絞り込めます。
           </p>
         </div>
@@ -423,6 +451,7 @@ export function SearchFilters({
                   key={category.value}
                   className={cn(
                     "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm",
+                    "focus-within:outline focus-within:outline-2 focus-within:outline-ring",
                     checked
                       ? "border-primary bg-primary/10 text-primary"
                       : "border-input bg-background",
@@ -482,46 +511,51 @@ export function SearchFilters({
           ) : null}
         </div>
 
-        <div className="space-y-3 rounded-lg border border-dashed p-4">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-              <p className="text-sm font-medium">現在地と距離</p>
-              <div
+        <section
+          aria-labelledby="gym-search-location-heading"
+          className="space-y-4 rounded-xl border border-dashed border-border/70 bg-muted/20 p-4"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex min-w-0 flex-col gap-2">
+              <h3 className="text-sm font-semibold" id="gym-search-location-heading">
+                現在地の設定
+              </h3>
+              <p
                 aria-live="polite"
-                className="flex items-start gap-2 text-xs text-muted-foreground"
+                className="flex items-start gap-2 text-xs leading-relaxed text-muted-foreground"
+                id={locationSummaryId}
               >
                 {isLocating ? (
-                  <Loader2
-                    aria-hidden="true"
-                    className="mt-0.5 h-3.5 w-3.5 animate-spin"
-                  />
+                  <Loader2 aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 animate-spin" />
                 ) : null}
                 {location.status === "error" ? (
-                  <AlertTriangle
-                    aria-hidden="true"
-                    className="mt-0.5 h-3.5 w-3.5 text-amber-500"
-                  />
+                  <AlertTriangle aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 text-amber-500" />
                 ) : null}
                 <span className="break-words">{locationSummary}</span>
-              </div>
+              </p>
             </div>
             <div className="flex flex-wrap gap-2">
-              <Button onClick={onRequestLocation} size="sm" type="button" disabled={isLocating}>
+              <Button
+                disabled={isLocating || !location.isSupported}
+                onClick={onRequestLocation}
+                size="sm"
+                type="button"
+              >
                 {isLocating ? (
                   <span className="flex items-center gap-2">
                     <Loader2 aria-hidden="true" className="h-3.5 w-3.5 animate-spin" />
                     取得中…
                   </span>
                 ) : (
-                  "現在地を再取得"
+                  location.isSupported ? "現在地を再取得" : "現在地は利用不可"
                 )}
               </Button>
               <Button
+                disabled={location.isFallback && location.status !== "error"}
                 onClick={handleUseFallbackLocation}
                 size="sm"
                 type="button"
                 variant="outline"
-                disabled={location.isFallback && location.status !== "error"}
               >
                 デフォルト地点を使用
               </Button>
@@ -538,7 +572,7 @@ export function SearchFilters({
           </div>
           {location.status === "error" && location.error ? (
             <div
-              className="flex flex-col gap-3 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive"
+              className="space-y-2 rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive shadow-sm"
               role="alert"
             >
               <div className="flex items-start gap-2 text-sm">
@@ -546,7 +580,7 @@ export function SearchFilters({
                 <span>{location.error}</span>
               </div>
               <button
-                className="self-start text-xs font-medium text-primary underline-offset-4 hover:underline"
+                className="text-left text-xs font-medium text-primary underline-offset-4 hover:underline"
                 onClick={() => {
                   keywordInputRef.current?.focus();
                   keywordInputRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -557,101 +591,130 @@ export function SearchFilters({
               </button>
             </div>
           ) : null}
-          <div className="grid gap-2 sm:grid-cols-2">
-            <div className="grid min-w-0 gap-1">
-              <label className="text-xs font-medium text-muted-foreground" htmlFor="manual-lat">
-                緯度（-90〜90）
-              </label>
-              <input
-                autoComplete="off"
-                className={cn(
-                  "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                )}
-                id="manual-lat"
-                inputMode="decimal"
-                onChange={(event) => {
-                  setLatInput(event.target.value);
-                  setManualError(null);
-                }}
-                placeholder="35.6895"
-                value={latInput}
-              />
+          <div className="space-y-3 rounded-lg border border-border/60 bg-background/80 p-3 shadow-sm">
+            <p className="text-xs text-muted-foreground" id={manualLocationHintId}>
+              緯度・経度を直接入力して検索範囲の中心を指定できます（例: 35.6895 / 139.6917）。
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="grid min-w-0 gap-1">
+                <label className="text-xs font-medium text-muted-foreground" htmlFor="manual-lat">
+                  緯度（-90〜90）
+                </label>
+                <input
+                  aria-describedby={manualLocationDescriptionIds}
+                  autoComplete="off"
+                  className={cn(
+                    "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  )}
+                  id="manual-lat"
+                  inputMode="decimal"
+                  onChange={(event) => {
+                    setLatInput(event.target.value);
+                    setManualError(null);
+                  }}
+                  placeholder="35.6895"
+                  value={latInput}
+                />
+              </div>
+              <div className="grid min-w-0 gap-1">
+                <label className="text-xs font-medium text-muted-foreground" htmlFor="manual-lng">
+                  経度（-180〜180）
+                </label>
+                <input
+                  aria-describedby={manualLocationDescriptionIds}
+                  autoComplete="off"
+                  className={cn(
+                    "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  )}
+                  id="manual-lng"
+                  inputMode="decimal"
+                  onChange={(event) => {
+                    setLngInput(event.target.value);
+                    setManualError(null);
+                  }}
+                  placeholder="139.6917"
+                  value={lngInput}
+                />
+              </div>
             </div>
-            <div className="grid min-w-0 gap-1">
-              <label className="text-xs font-medium text-muted-foreground" htmlFor="manual-lng">
-                経度（-180〜180）
-              </label>
-              <input
-                autoComplete="off"
-                className={cn(
-                  "h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                )}
-                id="manual-lng"
-                inputMode="decimal"
-                onChange={(event) => {
-                  setLngInput(event.target.value);
-                  setManualError(null);
-                }}
-                placeholder="139.6917"
-                value={lngInput}
-              />
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                disabled={!canApplyManual}
+                onClick={handleManualLocationApply}
+                size="sm"
+                type="button"
+              >
+                この座標で検索
+              </Button>
+              {hasLocation ? (
+                <span className="break-words text-xs text-muted-foreground">
+                  適用中: {coordinateLabel}
+                </span>
+              ) : null}
             </div>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              disabled={!canApplyManual}
-              onClick={handleManualLocationApply}
-              size="sm"
-              type="button"
-            >
-              この座標で検索
-            </Button>
-            {hasLocation ? (
-              <span className="break-words text-xs text-muted-foreground">
-                適用中: {coordinateLabel}
-              </span>
+            {manualError ? (
+              <p className="text-xs text-destructive" id={manualLocationErrorId} role="alert">
+                {manualError}
+              </p>
             ) : null}
           </div>
-          {manualError ? <p className="text-xs text-destructive">{manualError}</p> : null}
-        </div>
+        </section>
 
-        <div className="grid gap-2">
-          <div className="flex items-center justify-between gap-2">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
             <label className="text-sm font-medium" htmlFor="gym-search-distance">
               検索半径（km）
             </label>
             <SearchDistanceBadge distanceKm={state.distance} />
           </div>
-          <input
-            aria-valuemin={MIN_DISTANCE_KM}
-            aria-valuemax={MAX_DISTANCE_KM}
-            aria-valuenow={state.distance}
-            aria-label="検索半径（キロメートル）"
-            className={cn("w-full", !hasLocation && "opacity-50")}
-            id="gym-search-distance"
-            max={MAX_DISTANCE_KM}
-            min={MIN_DISTANCE_KM}
-            onChange={(event) =>
-              onDistanceChange(Number.parseInt(event.target.value, 10))
-            }
-            step={DISTANCE_STEP_KM}
-            type="range"
-            value={state.distance}
-            disabled={!hasLocation}
-          />
-          <span className="text-xs text-muted-foreground">
+          <div className="grid gap-2">
+            <input
+              aria-describedby={distanceHelpTextId}
+              aria-label="検索半径（キロメートル）"
+              aria-valuemax={MAX_DISTANCE_KM}
+              aria-valuemin={MIN_DISTANCE_KM}
+              aria-valuenow={state.distance}
+              aria-valuetext={`約${state.distance}キロメートル`}
+              className={cn("hidden w-full sm:block", !hasLocation && "opacity-50")}
+              disabled={!hasLocation}
+              id="gym-search-distance"
+              max={MAX_DISTANCE_KM}
+              min={MIN_DISTANCE_KM}
+              onChange={(event) => onDistanceChange(Number.parseInt(event.target.value, 10))}
+              step={DISTANCE_STEP_KM}
+              type="range"
+              value={state.distance}
+            />
+            <select
+              aria-describedby={distanceHelpTextId}
+              className={cn(
+                "h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm sm:hidden",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              )}
+              disabled={!hasLocation}
+              id="gym-search-distance-select"
+              onChange={(event) => {
+                const next = Number.parseInt(event.target.value, 10);
+                if (!Number.isNaN(next)) {
+                  onDistanceChange(next);
+                }
+              }}
+              value={state.distance}
+            >
+              {distanceOptions.map((option) => (
+                <option key={option} value={option}>
+                  半径 {option}km
+                </option>
+              ))}
+            </select>
+          </div>
+          <p className="text-xs leading-relaxed text-muted-foreground" id={distanceHelpTextId}>
             {hasLocation
               ? "現在の地点から検索する範囲を調整できます。"
               : `デフォルト地点（${FALLBACK_LOCATION.label}）または現在地を設定すると距離フィルタを利用できます。`}
-          </span>
-        </div>
-
-        <div className="flex flex-wrap justify-end gap-3">
-          <Button onClick={onClear} type="button" variant="outline">
-            条件をクリア
-          </Button>
+          </p>
         </div>
       </form>
 
@@ -659,7 +722,7 @@ export function SearchFilters({
         <div
           aria-live="polite"
           className={cn(
-            "rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm",
+            "rounded-xl border border-destructive/40 bg-destructive/10 p-4 text-sm shadow-sm",
             "text-destructive",
           )}
         >
@@ -676,7 +739,7 @@ export function SearchFilters({
         <div
           aria-live="polite"
           className={cn(
-            "rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm",
+            "rounded-xl border border-destructive/40 bg-destructive/10 p-4 text-sm shadow-sm",
             "text-destructive",
           )}
         >

--- a/frontend/src/components/search/SearchEmpty.tsx
+++ b/frontend/src/components/search/SearchEmpty.tsx
@@ -13,8 +13,9 @@ export function SearchEmpty({ onResetFilters, className }: SearchEmptyProps) {
     <div
       aria-live="polite"
       className={cn(
-        "flex flex-col items-center gap-4 rounded-lg border border-dashed",
-        "border-muted-foreground/40 bg-muted/20 p-8 text-center",
+        "flex flex-col items-center gap-5 rounded-2xl border border-dashed",
+        "border-muted-foreground/40 bg-muted/20 p-8 text-center shadow-sm sm:p-10",
+        "max-w-2xl mx-auto",
         className,
       )}
       role="status"

--- a/frontend/src/components/search/SearchError.tsx
+++ b/frontend/src/components/search/SearchError.tsx
@@ -15,8 +15,8 @@ export function SearchError({ message, onRetry, className }: SearchErrorProps) {
   return (
     <div
       className={cn(
-        "flex flex-col items-center gap-4 rounded-lg border border-destructive/40",
-        "bg-destructive/10 p-6 text-center text-sm text-destructive",
+        "flex flex-col items-center gap-4 rounded-2xl border border-destructive/40",
+        "bg-destructive/10 p-6 text-center text-sm text-destructive shadow-sm sm:p-8",
         className,
       )}
       role="alert"

--- a/frontend/src/components/search/SearchSkeleton.tsx
+++ b/frontend/src/components/search/SearchSkeleton.tsx
@@ -19,7 +19,14 @@ export function SearchSkeleton({ count = DEFAULT_SKELETON_COUNT, className }: Se
       </span>
       <div
         aria-hidden="true"
-        className={cn("grid gap-4 sm:grid-cols-2 xl:grid-cols-3", className)}
+        className={cn(
+          "grid gap-4",
+          "sm:grid-cols-2 sm:gap-6",
+          "lg:grid-cols-2",
+          "xl:grid-cols-3 xl:gap-7",
+          "2xl:grid-cols-4",
+          className,
+        )}
       >
         {items.map((_, index) => (
           <Card data-testid="search-result-skeleton" key={index} className="overflow-hidden">

--- a/frontend/src/features/gyms/GymsPage.tsx
+++ b/frontend/src/features/gyms/GymsPage.tsx
@@ -42,16 +42,18 @@ export function GymsPage() {
   } = useGymSearch();
 
   return (
-    <div className="flex min-h-screen w-full flex-col gap-10 px-4 py-10">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
-        <header className="space-y-2">
-          <p className="text-sm uppercase tracking-wide text-muted-foreground">Gym Directory</p>
-          <h1 className="text-3xl font-bold sm:text-4xl">ジム一覧・検索</h1>
-          <p className="text-sm text-muted-foreground">
+    <div className="flex min-h-screen w-full flex-col bg-muted/10">
+      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-4 pb-16 pt-8 sm:gap-10 sm:pt-12 lg:px-6 xl:px-0">
+        <header className="space-y-3 sm:space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground sm:text-sm">
+            Gym Directory
+          </p>
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">ジム一覧・検索</h1>
+          <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground sm:text-base">
             設備カテゴリやエリアで絞り込み、URL 共有で同じ検索条件を再現できます。
           </p>
         </header>
-        <div className="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,360px)_minmax(0,1fr)] lg:items-start xl:grid-cols-[minmax(0,380px)_minmax(0,1fr)] xl:gap-8">
           <SearchFilters
             categories={equipmentCategories}
             cities={cities}


### PR DESCRIPTION
## 変更概要
- ジム検索ページ全体のレイアウトを再調整し、主要ブレークポイントごとの余白・グリッド・カード比率を最適化
- フィルターフォームをモバイルでも使いやすい sticky セクションに再構成し、位置情報・距離設定のアクセシビリティと操作性を強化
- カード／ローディング／空・エラー表示のスタイルを共通トークンで刷新し、読みやすさとテーマ一貫性を向上

## 動作確認方法
- `npm run dev` を実行し、以下を確認
  - PC (1280px 以上): `/gyms` を表示し、3 カラム以上でカードが自然に並び、ヘッダーや余白が破綻しないこと
  - モバイル (≤ 390px 相当): `/gyms` を表示し、検索フォームが上部に固定されて折り返しなく操作できること
  - キーボード操作: キーワード入力 → `Tab` でフィルター群へ移動 → `Space/Enter` でカテゴリ切替 → 距離スライダーを矢印キーで調整 → `Enter` で検索実行 → `Tab` でページネーションを操作し遷移できること

## 既知の課題
- `npm run format:check` はリポジトリ全体の既存コードが Prettier の整形規則と乖離しているため失敗します（ベースブランチでも同様）

## スクリーンショット
- モバイル: ![gyms-mobile](browser:/invocations/xkebcuen/artifacts/artifacts/gyms-mobile.png)
- デスクトップ: ![gyms-desktop](browser:/invocations/bahiqyxq/artifacts/artifacts/gyms-desktop.png)

------
https://chatgpt.com/codex/tasks/task_e_68d3bf65b498832a938f5315fe8f953f