### PR TITLE
FE5b: Add minimal E2E smoke test

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,6 +4,14 @@ export default defineConfig({
   testDir: "./tests/e2e",
   timeout: 30 * 1000,
   retries: 0,
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+  },
+  webServer: {
+    command: "npm run dev -- --hostname 127.0.0.1 --port 3000",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+  },
   projects: [
     {
       name: "chromium",

--- a/frontend/tests/e2e/home.spec.ts
+++ b/frontend/tests/e2e/home.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "@playwright/test";
+
+test("トップページにヘルスチェック UI が表示される", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { level: 1, name: "API ヘルスチェック" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "再チェック" })).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "typecheck": "npm run typecheck --prefix frontend",
     "test:unit": "npm run test:unit --prefix frontend",
     "test:integration": "npm run test:integration --prefix frontend",
+    "test:e2e": "npm run test:e2e --prefix frontend",
     "test:ci": "npm run lint && npm run typecheck && npm run test:unit && npm run test:integration"
   }
 }


### PR DESCRIPTION
## Summary
- add a Playwright smoke test that opens the home page and checks for the health check UI
- configure the Playwright test runner to launch the Next.js dev server with a consistent base URL
- expose a root-level npm script to run the frontend E2E suite

## Testing
- npm run lint
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d3e270bacc832a8a362737e634f587