### PR TITLE
FE5c: Add search happy path E2E and integrate with PR-light CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,15 @@ name: Main CI
 on:
   push:
     branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   backend:
     name: Backend tests with coverage
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: github.event_name == 'push'
     env:
       POSTGRES_DB: gym_test
       POSTGRES_USER: postgres
@@ -75,3 +78,30 @@ jobs:
         with:
           name: coverage
           path: coverage.xml
+
+  frontend-e2e:
+    name: Frontend E2E (Chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: frontend
+        run: npm run e2e:install
+
+      - name: Run frontend E2E tests
+        working-directory: frontend
+        run: npm run test:e2e

--- a/frontend/tests/e2e/search.spec.ts
+++ b/frontend/tests/e2e/search.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "@playwright/test";
+
+test("検索キーワードでジム一覧を表示できる", async ({ page }) => {
+  const emptyResults = {
+    items: [],
+    meta: {
+      total: 0,
+      page: 1,
+      perPage: 20,
+      hasNext: false,
+      hasPrev: false,
+      hasMore: false,
+      pageToken: null,
+    },
+  };
+
+  const benchResults = {
+    items: [
+      {
+        id: 101,
+        slug: "bench-press-studio",
+        name: "Bench Press Studio",
+        city: "千代田区",
+        prefecture: "東京都",
+        address: "東京都千代田区丸の内1-1-1",
+        equipments: ["ベンチプレス", "ダンベル"],
+        thumbnailUrl: null,
+        score: 4.8,
+        lastVerifiedAt: "2024-01-15T00:00:00Z",
+      },
+    ],
+    meta: {
+      total: 1,
+      page: 1,
+      perPage: 20,
+      hasNext: false,
+      hasPrev: false,
+      hasMore: false,
+      pageToken: null,
+    },
+  };
+
+  await page.route("**/meta/prefectures", async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(["tokyo"]),
+    });
+  });
+
+  await page.route("**/meta/equipment-categories", async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(["strength"]),
+    });
+  });
+
+  await page.route("**/meta/cities**", async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.route("**/suggest/gyms**", async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          slug: "bench-press-studio",
+          name: "Bench Press Studio",
+          pref: "tokyo",
+          city: "chiyoda",
+        },
+      ]),
+    });
+  });
+
+  await page.route("**/gyms/search**", async route => {
+    const url = new URL(route.request().url());
+    const keyword = (url.searchParams.get("q") ?? "").trim().toLowerCase();
+    const response = keyword === "bench" ? benchResults : emptyResults;
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(response),
+    });
+  });
+
+  await page.goto("/gyms");
+
+  await page.waitForResponse(response => response.url().includes("/gyms/search"));
+
+  await page.getByLabel("キーワード").fill("bench");
+
+  const submitButton = page.getByRole("button", { name: "検索を実行" });
+  await expect(submitButton).toBeEnabled();
+
+  const searchResponse = page.waitForResponse(response => {
+    if (!response.url().includes("/gyms/search")) {
+      return false;
+    }
+    try {
+      const url = new URL(response.url());
+      return (url.searchParams.get("q") ?? "").trim().toLowerCase() === "bench";
+    } catch (error) {
+      return false;
+    }
+  });
+
+  await Promise.all([searchResponse, submitButton.click()]);
+
+  const resultsSection = page.locator("section[aria-labelledby='gym-search-results-heading']");
+  await expect(resultsSection).toBeVisible();
+  await expect(resultsSection.locator("a").first()).toContainText("Bench Press Studio");
+});


### PR DESCRIPTION
## Summary
- add a Playwright search happy-path E2E test that stubs API responses so the UI can be exercised without backend dependencies
- run the frontend Playwright suite (Chromium only) from the PR-light CI workflow while keeping backend coverage on main pushes

## Testing
- npm run e2e:install
- npm run test:e2e
- npx prettier --check tests/e2e/search.spec.ts
- PYENV_VERSION=3.11.12 ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d3ec532a60832aad58e4f22045b63f