### PR TITLE
FE: Search UI polish (radius, geolocation, URL sync, pagination)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run --passWithNoTests",
-  "test:unit": "vitest run --passWithNoTests --exclude \"tests/integration/**/*.int.test.ts*\" --exclude \"tests/e2e/**\"",
+    "test:unit": "vitest run --passWithNoTests --exclude \"tests/integration/**/*.int.test.ts*\" --exclude \"tests/e2e/**\"",
     "test:integration": "vitest run --config vitest.config.ts --passWithNoTests -t 'int' tests/integration",
     "test:e2e": "playwright test --project=chromium",
     "e2e:install": "playwright install --with-deps chromium"

--- a/frontend/src/components/gyms/SearchFilters.tsx
+++ b/frontend/src/components/gyms/SearchFilters.tsx
@@ -551,7 +551,11 @@ export function SearchFilters({
                   </span>
                 ) : mounted ? (
                   // マウント後は実際のサポート状況に基づいて表示
-                  location.isSupported ? "現在地を再取得" : "現在地は利用不可"
+                  location.isSupported ? (
+                    "現在地を再取得"
+                  ) : (
+                    "現在地は利用不可"
+                  )
                 ) : (
                   // SSR と初回 CSR を一致させるため固定表示
                   "現在地は利用不可"

--- a/frontend/src/features/gyms/nearby/components/NearbySearchPanel.tsx
+++ b/frontend/src/features/gyms/nearby/components/NearbySearchPanel.tsx
@@ -1,38 +1,63 @@
 "use client";
 
-import { FormEvent } from "react";
+import { FormEvent, useMemo } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 
+import { SearchDistanceBadge } from "@/components/search/SearchDistanceBadge";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { LocationStatus } from "@/features/gyms/nearby/useNearbySearchController";
 
 export interface NearbySearchPanelProps {
   latInput: string;
   lngInput: string;
-  radiusInput: string;
+  radiusKm: number;
+  radiusMin: number;
+  radiusMax: number;
+  radiusStep: number;
+  locationSummary: string;
+  locationStatus: LocationStatus;
+  locationError: string | null;
+  manualError: string | null;
   isLocating: boolean;
+  isLocationSupported: boolean;
   onLatChange: (value: string) => void;
   onLngChange: (value: string) => void;
-  onRadiusChange: (value: string) => void;
+  onRadiusChange: (value: number) => void;
   onSubmit: () => void;
   onUseCurrentLocation: () => void;
-  errorMessage: string | null;
 }
 
 export function NearbySearchPanel({
   latInput,
   lngInput,
-  radiusInput,
+  radiusKm,
+  radiusMin,
+  radiusMax,
+  radiusStep,
+  locationSummary,
+  locationStatus,
+  locationError,
+  manualError,
   isLocating,
+  isLocationSupported,
   onLatChange,
   onLngChange,
   onRadiusChange,
   onSubmit,
   onUseCurrentLocation,
-  errorMessage,
 }: NearbySearchPanelProps) {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     onSubmit();
   };
+
+  const radiusOptions = useMemo(() => {
+    const count = Math.floor((radiusMax - radiusMin) / radiusStep);
+    return Array.from({ length: count + 1 }, (_, index) => radiusMin + index * radiusStep).filter(
+      value => value >= radiusMin && value <= radiusMax,
+    );
+  }, [radiusMax, radiusMin, radiusStep]);
 
   return (
     <form
@@ -40,6 +65,22 @@ export function NearbySearchPanel({
       className="grid gap-4 rounded-lg border bg-card p-4 shadow-sm sm:grid-cols-2 lg:grid-cols-1"
       onSubmit={handleSubmit}
     >
+      <div className="space-y-2 sm:col-span-2 lg:col-span-1">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-sm font-semibold text-foreground">検索中心の設定</h3>
+          <SearchDistanceBadge distanceKm={radiusKm} />
+        </div>
+        <p className="flex items-start gap-2 text-xs text-muted-foreground" role="status">
+          {locationStatus === "loading" ? (
+            <Loader2 aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 animate-spin" />
+          ) : null}
+          {locationStatus === "error" ? (
+            <AlertTriangle aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 text-amber-500" />
+          ) : null}
+          <span className="break-words">{locationSummary}</span>
+        </p>
+      </div>
+
       <div className="space-y-2">
         <label className="text-sm font-medium text-foreground" htmlFor="nearby-lat">
           緯度
@@ -52,7 +93,6 @@ export function NearbySearchPanel({
           name="lat"
           onChange={event => onLatChange(event.target.value)}
           placeholder="35.681236"
-          required
           value={latInput}
         />
       </div>
@@ -68,36 +108,81 @@ export function NearbySearchPanel({
           name="lng"
           onChange={event => onLngChange(event.target.value)}
           placeholder="139.767125"
-          required
           value={lngInput}
         />
       </div>
-      <div className="space-y-2 sm:col-span-2 lg:col-span-1">
-        <label className="text-sm font-medium text-foreground" htmlFor="nearby-radius">
-          検索半径 (メートル)
-        </label>
-        <input
-          className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          id="nearby-radius"
-          inputMode="numeric"
-          name="radius"
-          onChange={event => onRadiusChange(event.target.value)}
-          placeholder="3000"
-          value={radiusInput}
-        />
-      </div>
-      {errorMessage ? (
-        <p className="sm:col-span-2 lg:col-span-1 text-sm text-destructive" role="alert">
-          {errorMessage}
+      {manualError ? (
+        <p className="sm:col-span-2 lg:col-span-1 text-xs text-destructive" role="alert">
+          {manualError}
         </p>
       ) : null}
+
+      <div className="space-y-3 sm:col-span-2 lg:col-span-1">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <label className="text-sm font-medium text-foreground" htmlFor="nearby-radius">
+            検索半径（km）
+          </label>
+          <span className="text-xs text-muted-foreground">地図と一覧の対象範囲を調整します。</span>
+        </div>
+        <div className="grid gap-2">
+          <input
+            aria-label="検索半径（キロメートル）"
+            className="hidden w-full sm:block"
+            id="nearby-radius"
+            max={radiusMax}
+            min={radiusMin}
+            onChange={event => {
+              const next = Number.parseInt(event.target.value, 10);
+              if (!Number.isNaN(next)) {
+                onRadiusChange(next);
+              }
+            }}
+            step={radiusStep}
+            type="range"
+            value={radiusKm}
+          />
+          <select
+            aria-label="検索半径を選択"
+            className={cn(
+              "h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring",
+              "sm:hidden",
+            )}
+            onChange={event => {
+              const next = Number.parseInt(event.target.value, 10);
+              if (!Number.isNaN(next)) {
+                onRadiusChange(next);
+              }
+            }}
+            value={radiusKm}
+          >
+            {radiusOptions.map(option => (
+              <option key={option} value={option}>
+                半径 {option}km
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {locationError ? (
+        <div
+          className="sm:col-span-2 lg:col-span-1 rounded-md border border-amber-300/80 bg-amber-50/70 p-3 text-xs text-amber-700 shadow-sm"
+          role="alert"
+        >
+          <div className="flex items-start gap-2">
+            <AlertTriangle aria-hidden="true" className="mt-0.5 h-4 w-4" />
+            <span>{locationError}</span>
+          </div>
+        </div>
+      ) : null}
+
       <div className="flex flex-col gap-2 sm:col-span-2 lg:col-span-1 sm:flex-row">
         <Button className="w-full sm:w-auto" type="submit">
           この座標で検索
         </Button>
         <Button
           className="w-full sm:w-auto"
-          disabled={isLocating}
+          disabled={isLocating || !isLocationSupported}
           onClick={event => {
             event.preventDefault();
             onUseCurrentLocation();
@@ -105,7 +190,14 @@ export function NearbySearchPanel({
           type="button"
           variant="outline"
         >
-          {isLocating ? "現在地取得中..." : "現在地を使用"}
+          {isLocating ? (
+            <span className="flex items-center gap-2">
+              <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+              取得中...
+            </span>
+          ) : (
+            "現在地を取得"
+          )}
         </Button>
       </div>
     </form>

--- a/frontend/src/features/gyms/nearby/useNearbySearchController.ts
+++ b/frontend/src/features/gyms/nearby/useNearbySearchController.ts
@@ -1,0 +1,417 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  clampLatitude,
+  clampLongitude,
+  DISTANCE_STEP_KM,
+  MAX_DISTANCE_KM,
+  MIN_DISTANCE_KM,
+} from "@/lib/searchParams";
+
+const DEFAULT_RADIUS_KM = 3;
+
+const clampRadius = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_RADIUS_KM;
+  }
+  const rounded = Math.round(value);
+  return Math.min(Math.max(rounded, MIN_DISTANCE_KM), MAX_DISTANCE_KM);
+};
+
+const parseRadius = (raw: string | null): number | null => {
+  if (raw == null) {
+    return null;
+  }
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return clampRadius(parsed);
+};
+
+const parsePage = (raw: string | null): number => {
+  if (!raw) {
+    return 1;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return 1;
+  }
+  return parsed;
+};
+
+const buildNearbyQuery = (state: NearbyQueryState): URLSearchParams => {
+  const params = new URLSearchParams();
+  params.set("lat", state.lat.toFixed(6));
+  params.set("lng", state.lng.toFixed(6));
+  params.set("radiusKm", String(state.radiusKm));
+  params.set("page", String(state.page));
+  return params;
+};
+
+const GEO_PERMISSION_DENIED_MESSAGE =
+  "位置情報が許可されていません。手動入力や地図から地点を選択してください。";
+const GEO_UNAVAILABLE_MESSAGE =
+  "現在地を取得できませんでした。通信環境をご確認いただくか、手動で地点を指定してください。";
+const GEO_TIMEOUT_MESSAGE =
+  "位置情報の取得がタイムアウトしました。再度お試しいただくか、手動で地点を指定してください。";
+const GEO_UNSUPPORTED_MESSAGE =
+  "この環境では位置情報を取得できません。緯度・経度を入力するか地図を操作してください。";
+
+const parseNearbyState = (
+  params: ReadonlyURLSearchParams,
+  defaults: { lat: number; lng: number; radiusKm: number },
+): NearbyQueryState => {
+  const latRaw = params.get("lat");
+  const lngRaw = params.get("lng");
+  const lat = latRaw == null ? defaults.lat : clampLatitude(Number.parseFloat(latRaw));
+  const lng = lngRaw == null ? defaults.lng : clampLongitude(Number.parseFloat(lngRaw));
+
+  const radiusParam = params.get("radiusKm") ?? params.get("radius_km") ?? params.get("radius");
+  const radius = parseRadius(radiusParam) ?? defaults.radiusKm;
+
+  const page = parsePage(params.get("page"));
+
+  return {
+    lat: Number.isFinite(lat) ? lat : defaults.lat,
+    lng: Number.isFinite(lng) ? lng : defaults.lng,
+    radiusKm: radius,
+    page,
+  };
+};
+
+const areStatesEqual = (a: NearbyQueryState, b: NearbyQueryState) =>
+  Math.abs(a.lat - b.lat) < 1e-9 &&
+  Math.abs(a.lng - b.lng) < 1e-9 &&
+  a.radiusKm === b.radiusKm &&
+  a.page === b.page;
+
+export type LocationStatus = "idle" | "loading" | "success" | "error";
+export type LocationMode = "url" | "auto" | "manual" | "map";
+
+export interface NearbyQueryState {
+  lat: number;
+  lng: number;
+  radiusKm: number;
+  page: number;
+}
+
+export interface NearbyFormState {
+  latInput: string;
+  lngInput: string;
+  radiusKm: number;
+}
+
+export interface NearbyLocationState {
+  status: LocationStatus;
+  error: string | null;
+  isSupported: boolean;
+  mode: LocationMode;
+  hasExplicitLocation: boolean;
+}
+
+export interface UseNearbySearchControllerOptions {
+  defaultCenter: { lat: number; lng: number };
+  defaultRadiusKm?: number;
+}
+
+export interface UseNearbySearchControllerResult {
+  applied: NearbyQueryState;
+  formState: NearbyFormState;
+  manualError: string | null;
+  location: NearbyLocationState;
+  radiusBounds: { min: number; max: number; step: number };
+  setLatInput: (value: string) => void;
+  setLngInput: (value: string) => void;
+  updateRadius: (value: number) => void;
+  submitManualCoordinates: () => void;
+  updateCenterFromMap: (center: { lat: number; lng: number }) => void;
+  requestCurrentLocation: () => void;
+  setPage: (page: number) => void;
+}
+
+type ReadonlyURLSearchParams = ReturnType<typeof useSearchParams>;
+
+export function useNearbySearchController({
+  defaultCenter,
+  defaultRadiusKm = DEFAULT_RADIUS_KM,
+}: UseNearbySearchControllerOptions): UseNearbySearchControllerResult {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsKey = searchParams.toString();
+
+  const resolvedDefaults = useMemo(
+    () => ({
+      lat: clampLatitude(defaultCenter.lat),
+      lng: clampLongitude(defaultCenter.lng),
+      radiusKm: clampRadius(defaultRadiusKm),
+    }),
+    [defaultCenter.lat, defaultCenter.lng, defaultRadiusKm],
+  );
+
+  const geolocationSupportedRef = useRef(
+    typeof window !== "undefined" &&
+      typeof window.navigator !== "undefined" &&
+      "geolocation" in window.navigator,
+  );
+
+  const [applied, setApplied] = useState<NearbyQueryState>(() =>
+    parseNearbyState(searchParams, resolvedDefaults),
+  );
+  const [hasExplicitLocation, setHasExplicitLocation] = useState(() => {
+    const params = new URLSearchParams(searchParamsKey);
+    return params.has("lat") && params.has("lng");
+  });
+  const [formState, setFormState] = useState<NearbyFormState>(() => ({
+    latInput: applied.lat.toFixed(6),
+    lngInput: applied.lng.toFixed(6),
+    radiusKm: applied.radiusKm,
+  }));
+  const [manualError, setManualError] = useState<string | null>(null);
+  const [locationStatus, setLocationStatus] = useState<LocationStatus>("success");
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const [locationMode, setLocationMode] = useState<LocationMode>("url");
+
+  const pendingSourceRef = useRef<LocationMode | null>(null);
+
+  const applyQuery = useCallback(
+    (next: NearbyQueryState, options: { replace?: boolean; source?: LocationMode } = {}) => {
+      const isSame = areStatesEqual(applied, next);
+      setApplied(next);
+      setFormState({
+        latInput: next.lat.toFixed(6),
+        lngInput: next.lng.toFixed(6),
+        radiusKm: next.radiusKm,
+      });
+      setManualError(null);
+
+      if (options.source) {
+        setLocationMode(options.source);
+        if (options.source !== "url") {
+          setLocationStatus("success");
+          setLocationError(null);
+        }
+      }
+
+      if (isSame) {
+        pendingSourceRef.current = null;
+        return;
+      }
+
+      pendingSourceRef.current = options.source ?? null;
+      const params = buildNearbyQuery(next);
+      const nextQuery = params.toString();
+      const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname;
+      const method = options.replace ? router.replace : router.push;
+      method(nextUrl, { scroll: false });
+      setHasExplicitLocation(true);
+    },
+    [applied, pathname, router],
+  );
+
+  useEffect(() => {
+    const parsed = parseNearbyState(new URLSearchParams(searchParamsKey), resolvedDefaults);
+    setApplied(prev => (areStatesEqual(prev, parsed) ? prev : parsed));
+    const params = new URLSearchParams(searchParamsKey);
+    setHasExplicitLocation(params.has("lat") && params.has("lng"));
+    setFormState(prev => {
+      if (
+        prev.latInput === parsed.lat.toFixed(6) &&
+        prev.lngInput === parsed.lng.toFixed(6) &&
+        prev.radiusKm === parsed.radiusKm
+      ) {
+        return prev;
+      }
+      return {
+        latInput: parsed.lat.toFixed(6),
+        lngInput: parsed.lng.toFixed(6),
+        radiusKm: parsed.radiusKm,
+      };
+    });
+
+    const source = pendingSourceRef.current;
+    if (source) {
+      setLocationMode(source);
+      if (source !== "url") {
+        setLocationStatus("success");
+        setLocationError(null);
+      }
+    } else {
+      setLocationMode("url");
+      setLocationStatus(status => (status === "loading" ? "success" : status));
+    }
+    pendingSourceRef.current = null;
+  }, [resolvedDefaults, searchParamsKey]);
+
+  const setLatInput = useCallback((value: string) => {
+    setFormState(prev => ({ ...prev, latInput: value }));
+    setManualError(null);
+  }, []);
+
+  const setLngInput = useCallback((value: string) => {
+    setFormState(prev => ({ ...prev, lngInput: value }));
+    setManualError(null);
+  }, []);
+
+  const updateRadius = useCallback(
+    (value: number) => {
+      if (!Number.isFinite(value)) {
+        return;
+      }
+      const nextRadius = clampRadius(value);
+      if (nextRadius === formState.radiusKm && nextRadius === applied.radiusKm) {
+        return;
+      }
+      applyQuery(
+        {
+          ...applied,
+          radiusKm: nextRadius,
+          page: 1,
+        },
+        { source: locationMode },
+      );
+    },
+    [applied, applyQuery, formState.radiusKm, locationMode],
+  );
+
+  const submitManualCoordinates = useCallback(() => {
+    const latValue = Number.parseFloat(formState.latInput);
+    const lngValue = Number.parseFloat(formState.lngInput);
+    if (!Number.isFinite(latValue) || !Number.isFinite(lngValue)) {
+      setManualError("緯度・経度を数値で入力してください。（例: 35.681236）");
+      return;
+    }
+    const clampedLat = clampLatitude(latValue);
+    const clampedLng = clampLongitude(lngValue);
+    setManualError(null);
+    setLocationMode("manual");
+    setLocationStatus("success");
+    setLocationError(null);
+    applyQuery(
+      {
+        lat: clampedLat,
+        lng: clampedLng,
+        radiusKm: applied.radiusKm,
+        page: 1,
+      },
+      { source: "manual" },
+    );
+  }, [applied.radiusKm, applyQuery, formState.latInput, formState.lngInput]);
+
+  const updateCenterFromMap = useCallback(
+    (center: { lat: number; lng: number }) => {
+      const lat = clampLatitude(center.lat);
+      const lng = clampLongitude(center.lng);
+      applyQuery(
+        {
+          lat,
+          lng,
+          radiusKm: applied.radiusKm,
+          page: 1,
+        },
+        { source: "map" },
+      );
+    },
+    [applied.radiusKm, applyQuery],
+  );
+
+  const requestCurrentLocation = useCallback(() => {
+    if (typeof window === "undefined" || !geolocationSupportedRef.current) {
+      setLocationMode("auto");
+      setLocationStatus("error");
+      setLocationError(GEO_UNSUPPORTED_MESSAGE);
+      return;
+    }
+    setLocationMode("auto");
+    setLocationStatus("loading");
+    setLocationError(null);
+    window.navigator.geolocation.getCurrentPosition(
+      position => {
+        const lat = clampLatitude(position.coords.latitude);
+        const lng = clampLongitude(position.coords.longitude);
+        setLocationStatus("success");
+        setLocationError(null);
+        applyQuery(
+          {
+            lat,
+            lng,
+            radiusKm: applied.radiusKm,
+            page: 1,
+          },
+          { source: "auto" },
+        );
+      },
+      error => {
+        const PERM = error?.PERMISSION_DENIED ?? 1;
+        const UNAV = error?.POSITION_UNAVAILABLE ?? 2;
+        const TOUT = error?.TIMEOUT ?? 3;
+        let message = GEO_UNAVAILABLE_MESSAGE;
+        if (error.code === PERM) {
+          message = GEO_PERMISSION_DENIED_MESSAGE;
+        } else if (error.code === UNAV) {
+          message = GEO_UNAVAILABLE_MESSAGE;
+        } else if (error.code === TOUT) {
+          message = GEO_TIMEOUT_MESSAGE;
+        }
+        setLocationStatus("error");
+        setLocationError(message);
+      },
+      { enableHighAccuracy: false, maximumAge: 300000, timeout: 10000 },
+    );
+  }, [applied.radiusKm, applyQuery]);
+
+  const setPage = useCallback(
+    (page: number) => {
+      if (!Number.isFinite(page)) {
+        return;
+      }
+      const nextPage = Math.max(1, Math.trunc(page));
+      if (nextPage === applied.page) {
+        return;
+      }
+      applyQuery(
+        {
+          ...applied,
+          page: nextPage,
+        },
+        { source: locationMode },
+      );
+    },
+    [applied, applyQuery, locationMode],
+  );
+
+  const radiusBounds = useMemo(
+    () => ({ min: MIN_DISTANCE_KM, max: MAX_DISTANCE_KM, step: DISTANCE_STEP_KM }),
+    [],
+  );
+
+  const location: NearbyLocationState = useMemo(
+    () => ({
+      status: locationStatus,
+      error: locationError,
+      isSupported: geolocationSupportedRef.current,
+      mode: locationMode,
+      hasExplicitLocation,
+    }),
+    [hasExplicitLocation, locationError, locationMode, locationStatus],
+  );
+
+  return {
+    applied,
+    formState,
+    manualError,
+    location,
+    radiusBounds,
+    setLatInput,
+    setLngInput,
+    updateRadius,
+    submitManualCoordinates,
+    updateCenterFromMap,
+    requestCurrentLocation,
+    setPage,
+  };
+}

--- a/frontend/src/services/__tests__/gymNearby.test.ts
+++ b/frontend/src/services/__tests__/gymNearby.test.ts
@@ -26,7 +26,7 @@ describe("fetchNearbyGyms", () => {
         },
       ],
       total: 5,
-      page: 1,
+      page: 2,
       page_size: 20,
       has_more: true,
       has_prev: false,
@@ -43,6 +43,7 @@ describe("fetchNearbyGyms", () => {
       lng: 139.767125,
       radiusKm: 3,
       perPage: 20,
+      page: 2,
       pageToken: null,
     });
 
@@ -54,7 +55,7 @@ describe("fetchNearbyGyms", () => {
           lat: 35.681236,
           lng: 139.767125,
           radius_km: 3,
-          page: 1,
+          page: 2,
           page_size: 20,
         },
         signal: undefined,
@@ -76,11 +77,11 @@ describe("fetchNearbyGyms", () => {
         },
       ],
       total: 5,
-      page: 1,
+      page: 2,
       pageSize: 20,
       hasMore: true,
       hasPrev: false,
-      pageToken: "2",
+      pageToken: "3",
     });
   });
 
@@ -92,6 +93,7 @@ describe("fetchNearbyGyms", () => {
       lng: 20,
       radiusKm: 5,
       perPage: 10,
+      page: undefined,
       pageToken: "3",
       signal: controller.signal,
     });
@@ -101,6 +103,24 @@ describe("fetchNearbyGyms", () => {
       expect.objectContaining({
         signal: controller.signal,
         query: expect.objectContaining({ page: 3 }),
+      }),
+    );
+  });
+
+  it("prioritises the explicit page over the page token", async () => {
+    await fetchNearbyGyms({
+      lat: 10,
+      lng: 20,
+      radiusKm: 5,
+      perPage: 10,
+      page: 4,
+      pageToken: "8",
+    });
+
+    expect(mockedApiRequest).toHaveBeenLastCalledWith(
+      "/gyms/nearby",
+      expect.objectContaining({
+        query: expect.objectContaining({ page: 4 }),
       }),
     );
   });

--- a/frontend/src/services/gymNearby.ts
+++ b/frontend/src/services/gymNearby.ts
@@ -6,6 +6,7 @@ export interface FetchNearbyGymsParams {
   lng: number;
   radiusKm: number;
   perPage?: number;
+  page?: number;
   pageToken?: string | null;
   signal?: AbortSignal;
 }
@@ -50,12 +51,15 @@ export async function fetchNearbyGyms({
   lng,
   radiusKm,
   perPage = 20,
+  page,
   pageToken,
   signal,
 }: FetchNearbyGymsParams): Promise<GymNearbyResponse> {
   const parsedToken =
     pageToken != null && pageToken !== "" ? Number.parseInt(pageToken, 10) : Number.NaN;
-  const targetPage = Number.isFinite(parsedToken) && parsedToken > 0 ? parsedToken : 1;
+  const sanitizedPage = Number.isFinite(page) && page! > 0 ? Math.trunc(page!) : null;
+  const targetPage =
+    sanitizedPage ?? (Number.isFinite(parsedToken) && parsedToken > 0 ? parsedToken : 1);
   const query: Record<string, unknown> = {
     lat,
     lng,


### PR DESCRIPTION
## Summary
- add a URL-synchronised nearby search controller that manages radius, location modes, and current page state
- refactor the nearby gyms page, panel, and list to react to URL changes, show loading/empty/error UI, and drive pagination
- update the nearby gyms fetcher, service, and tests for page-aware responses and align prettier formatting in existing files

## Testing
- npm run lint
- CI=1 npm run format:check
- PYENV_VERSION=3.11.12 ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d3f180e050832a81c4644c24705772