### PR TITLE
feat: sync nearby list and map highlight

### DIFF
--- a/frontend/src/features/gyms/nearby/NearbyGymsPage.tsx
+++ b/frontend/src/features/gyms/nearby/NearbyGymsPage.tsx
@@ -81,7 +81,9 @@ export function NearbyGymsPage() {
   });
 
   const hoveredId = useMapSelectionStore(state => state.hoveredId);
+  const selectedId = useMapSelectionStore(state => state.selectedId);
   const setHoveredId = useMapSelectionStore(state => state.setHovered);
+  const setSelectedId = useMapSelectionStore(state => state.setSelected);
   const clearSelection = useMapSelectionStore(state => state.clear);
 
   useEffect(() => {
@@ -92,6 +94,15 @@ export function NearbyGymsPage() {
       setHoveredId(null);
     }
   }, [hoveredId, items, setHoveredId]);
+
+  useEffect(() => {
+    if (selectedId === null) {
+      return;
+    }
+    if (!items.some(gym => gym.id === selectedId)) {
+      setSelectedId(null);
+    }
+  }, [items, selectedId, setSelectedId]);
 
   useEffect(() => () => clearSelection(), [clearSelection]);
 

--- a/frontend/src/features/gyms/nearby/components/NearbyList.tsx
+++ b/frontend/src/features/gyms/nearby/components/NearbyList.tsx
@@ -94,6 +94,7 @@ export function NearbyList({
   error,
 }: NearbyListProps) {
   const hoveredId = useMapSelectionStore(state => state.hoveredId);
+  const selectedId = useMapSelectionStore(state => state.selectedId);
   const setHovered = useMapSelectionStore(state => state.setHovered);
   const setSelected = useMapSelectionStore(state => state.setSelected);
 
@@ -149,7 +150,8 @@ export function NearbyList({
       ) : (
         <ul className="space-y-3">
           {items.map(gym => {
-            const isHighlighted = hoveredId === gym.id;
+            const isHovered = hoveredId === gym.id;
+            const isSelected = selectedId === gym.id;
             const prefectureLabel = formatSlug(gym.prefecture);
             const cityLabel = formatSlug(gym.city);
             const areaLabel =
@@ -159,9 +161,11 @@ export function NearbyList({
                 <Link
                   className={cn(
                     "group block rounded-lg border bg-card p-4 text-left shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    isHighlighted
-                      ? "border-primary bg-primary/5"
-                      : "hover:border-primary hover:bg-primary/5",
+                    isSelected
+                      ? "border-primary bg-primary/10 shadow-md"
+                      : isHovered
+                        ? "border-primary bg-primary/5"
+                        : "hover:border-primary hover:bg-primary/5",
                   )}
                   href={`/gyms/${gym.slug}`}
                   onBlur={() => setHovered(null)}
@@ -174,7 +178,12 @@ export function NearbyList({
                   onMouseLeave={() => setHovered(null)}
                 >
                   <div className="flex items-center justify-between gap-2">
-                    <h3 className="text-base font-semibold text-foreground group-hover:text-primary">
+                    <h3
+                      className={cn(
+                        "text-base font-semibold text-foreground group-hover:text-primary",
+                        isSelected ? "text-primary" : null,
+                      )}
+                    >
                       {gym.name}
                     </h3>
                     <span className="rounded-full bg-secondary px-3 py-1 text-xs text-secondary-foreground">

--- a/frontend/src/state/__tests__/mapSelection.test.ts
+++ b/frontend/src/state/__tests__/mapSelection.test.ts
@@ -28,6 +28,16 @@ describe("mapSelectionStore", () => {
     expect(state.hoveredId).toBe(456);
   });
 
+  it("toggles the selected id when the same value is set", () => {
+    const { setSelected } = useMapSelectionStore.getState();
+
+    setSelected(42);
+    expect(mapSelectionStore.getState().selectedId).toBe(42);
+
+    setSelected(42);
+    expect(mapSelectionStore.getState().selectedId).toBeNull();
+  });
+
   it("clears both ids", () => {
     useMapSelectionStore.setState({ selectedId: 1, hoveredId: 2 });
 

--- a/frontend/src/state/mapSelection.ts
+++ b/frontend/src/state/mapSelection.ts
@@ -17,7 +17,10 @@ interface MapSelectionState {
 export const useMapSelectionStore = create<MapSelectionState>(set => ({
   selectedId: null,
   hoveredId: null,
-  setSelected: id => set({ selectedId: id }),
+  setSelected: id =>
+    set(current => ({
+      selectedId: id === null ? null : current.selectedId === id ? null : id,
+    })),
   setHovered: id => set({ hoveredId: id }),
   clear: () => set({ selectedId: null, hoveredId: null }),
 }));

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -15,6 +15,15 @@ export default defineConfig({
         url: "http://localhost",
       },
     },
+    sequence: {
+      concurrent: false,
+    },
+    poolOptions: {
+      threads: {
+        minThreads: 1,
+        maxThreads: 1,
+      },
+    },
   },
   resolve: {
     alias: [

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { server } from "./tests/msw/server";
+import { resetMapSelectionStoreForTests } from "@/state/mapSelection";
 
 const defaultApiBase = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8000";
 process.env.NEXT_PUBLIC_API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? defaultApiBase;
@@ -16,6 +17,7 @@ afterEach(() => {
   server.resetHandlers();
   cleanup();
   vi.clearAllMocks();
+  resetMapSelectionStoreForTests();
 });
 
 afterAll(() => {


### PR DESCRIPTION
## Summary
- sync nearby list interactions with the shared map selection store
- highlight hovered and selected map markers and list rows consistently
- toggle map selection when clicking the same item and cover it with tests

## Testing
- npm run lint
- npm run typecheck
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d4f61b2180832a96810545a10c1eb3