### PR TITLE
リスト操作に連動したマップのハイライト＆パン

### DIFF
--- a/frontend/src/features/gyms/nearby/components/NearbyList.tsx
+++ b/frontend/src/features/gyms/nearby/components/NearbyList.tsx
@@ -265,11 +265,11 @@ export function NearbyList({
                   href={`/gyms/${gym.slug}`}
                   onBlur={() => setHovered(null)}
                   onClick={() => {
-                    setSelected(gym.id);
+                    setSelected(gym.id, "list");
                     logPinClick({ source: "list", slug: gym.slug });
                   }}
-                  onFocus={() => setHovered(gym.id)}
-                  onMouseEnter={() => setHovered(gym.id)}
+                  onFocus={() => setHovered(gym.id, "list")}
+                  onMouseEnter={() => setHovered(gym.id, "list")}
                   onMouseLeave={() => setHovered(null)}
                 >
                   <div className="flex items-center justify-between gap-2">

--- a/frontend/src/features/gyms/nearby/components/__tests__/NearbyMapInteractions.test.tsx
+++ b/frontend/src/features/gyms/nearby/components/__tests__/NearbyMapInteractions.test.tsx
@@ -1,0 +1,277 @@
+import type { ComponentProps } from "react";
+
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NearbyMap } from "../NearbyMap";
+import { resetMapSelectionStoreForTests, useMapSelectionStore } from "@/state/mapSelection";
+import type { NearbyGym } from "@/types/gym";
+
+interface MockMapHandle {
+  emit: (event: string, ...args: unknown[]) => void;
+}
+
+const mockState = {
+  easeToCalls: [] as Array<{ center?: [number, number]; zoom?: number; duration?: number }>,
+  latestMap: null as MockMapHandle | null,
+};
+
+vi.mock("maplibre-gl", () => {
+  class MockMap {
+    container: HTMLElement;
+    center: { lng: number; lat: number };
+    zoom: number;
+    handlers: Map<string, Set<(...args: unknown[]) => void>> = new Map();
+
+    constructor(options: { container: HTMLElement; center: [number, number]; zoom?: number }) {
+      this.container = options.container;
+      this.center = { lng: options.center[0], lat: options.center[1] };
+      this.zoom = options.zoom ?? 13;
+      mockState.latestMap = this;
+    }
+
+    addControl() {
+      return this;
+    }
+
+    resize() {}
+
+    remove() {}
+
+    on(event: string, handler: (...args: unknown[]) => void) {
+      if (!this.handlers.has(event)) {
+        this.handlers.set(event, new Set());
+      }
+      this.handlers.get(event)!.add(handler);
+    }
+
+    off(event: string, handler: (...args: unknown[]) => void) {
+      const listeners = this.handlers.get(event);
+      if (!listeners) {
+        return;
+      }
+      listeners.delete(handler);
+    }
+
+    emit(event: string, ...args: unknown[]) {
+      const listeners = this.handlers.get(event);
+      if (!listeners) {
+        return;
+      }
+      listeners.forEach(listener => listener(...args));
+    }
+
+    getCenter() {
+      return { ...this.center };
+    }
+
+    getZoom() {
+      return this.zoom;
+    }
+
+    easeTo(options: { center: [number, number]; zoom?: number; duration?: number }) {
+      mockState.easeToCalls.push(options);
+      this.center = { lng: options.center[0], lat: options.center[1] };
+      if (typeof options.zoom === "number") {
+        this.zoom = options.zoom;
+      }
+      this.emit("moveend");
+    }
+  }
+
+  class MockMarker {
+    element: HTMLButtonElement;
+
+    constructor(options: { element: HTMLButtonElement }) {
+      this.element = options.element;
+    }
+
+    setLngLat() {
+      return this;
+    }
+
+    addTo(map: MockMap) {
+      map.container.appendChild(this.element);
+      return this;
+    }
+
+    remove() {
+      if (this.element.parentElement) {
+        this.element.parentElement.removeChild(this.element);
+      }
+    }
+  }
+
+  class MockNavigationControl {
+    constructor(_options: unknown) {}
+  }
+
+  return {
+    __esModule: true,
+    default: {
+      Map: MockMap,
+      Marker: MockMarker,
+      NavigationControl: MockNavigationControl,
+    },
+    Map: MockMap,
+    Marker: MockMarker,
+    NavigationControl: MockNavigationControl,
+  };
+});
+
+const gyms: NearbyGym[] = [
+  {
+    id: 1,
+    slug: "gym-one",
+    name: "ジムワン",
+    prefecture: "東京都",
+    city: "千代田区",
+    latitude: 35.6895,
+    longitude: 139.6917,
+    distanceKm: 0.5,
+  },
+  {
+    id: 2,
+    slug: "gym-two",
+    name: "ジムツー",
+    prefecture: "東京都",
+    city: "港区",
+    latitude: 35.6581,
+    longitude: 139.7516,
+    distanceKm: 1.1,
+  },
+];
+
+const renderMap = (props?: Partial<ComponentProps<typeof NearbyMap>>) =>
+  render(
+    <NearbyMap
+      center={{ lat: 35.68, lng: 139.76 }}
+      markers={gyms}
+      onMarkerSelect={() => undefined}
+      onCenterChange={() => undefined}
+      zoom={props?.zoom ?? 13}
+      {...props}
+    />,
+  );
+
+beforeEach(() => {
+  mockState.easeToCalls.length = 0;
+  mockState.latestMap = null;
+  resetMapSelectionStoreForTests();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("NearbyMap interactions", () => {
+  it("updates marker state when hover changes", async () => {
+    const { container } = renderMap();
+    await act(async () => {});
+
+    const mapContainer = container.firstElementChild as HTMLElement;
+    const marker = mapContainer.querySelector('[data-gym-id="2"]') as HTMLButtonElement | null;
+    expect(marker).not.toBeNull();
+    if (!marker) {
+      throw new Error("Marker was not created");
+    }
+
+    act(() => {
+      useMapSelectionStore.getState().setHovered(2, "list");
+    });
+
+    expect(marker.dataset.state).toBe("hovered");
+
+    act(() => {
+      useMapSelectionStore.getState().setSelected(2, "list");
+    });
+
+    expect(marker.dataset.state).toBe("selected");
+  });
+
+  it("pans to the selected gym with controlled zoom", async () => {
+    renderMap({ zoom: 10 });
+    await act(async () => {});
+
+    act(() => {
+      useMapSelectionStore.getState().setSelected(2, "list");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(mockState.easeToCalls).toHaveLength(1);
+    const [{ center, zoom, duration }] = mockState.easeToCalls;
+    expect(center).toEqual([gyms[1].longitude, gyms[1].latitude]);
+    expect(zoom).toBe(12);
+    expect(duration).toBe(500);
+  });
+
+  it("debounces repeated selections", async () => {
+    renderMap();
+    await act(async () => {});
+
+    act(() => {
+      useMapSelectionStore.getState().setSelected(2, "list");
+      useMapSelectionStore.getState().setSelected(2, "list");
+    });
+
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(mockState.easeToCalls).toHaveLength(1);
+  });
+
+  it("skips auto-pan when selection originates from the map", async () => {
+    renderMap();
+    await act(async () => {});
+
+    act(() => {
+      useMapSelectionStore.getState().setSelected(2, "map");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+      useMapSelectionStore.getState().setSelected(2, "list");
+    });
+
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(mockState.easeToCalls).toHaveLength(0);
+  });
+
+  it("does not pan while the user is dragging", async () => {
+    const { container } = renderMap();
+    await act(async () => {});
+
+    const mapContainer = container.firstElementChild as HTMLElement;
+    const marker = mapContainer.querySelector('[data-gym-id="1"]');
+    expect(marker).not.toBeNull();
+
+    act(() => {
+      mockState.latestMap?.emit("dragstart");
+      useMapSelectionStore.getState().setSelected(2, "list");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(mockState.easeToCalls).toHaveLength(0);
+
+    act(() => {
+      mockState.latestMap?.emit("dragend");
+      useMapSelectionStore.getState().setSelected(2, "list");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(mockState.easeToCalls).toHaveLength(1);
+  });
+});

--- a/frontend/src/state/__tests__/mapSelection.test.ts
+++ b/frontend/src/state/__tests__/mapSelection.test.ts
@@ -15,36 +15,57 @@ describe("mapSelectionStore", () => {
     const state = mapSelectionStore.getState();
     expect(state.selectedId).toBeNull();
     expect(state.hoveredId).toBeNull();
+    expect(state.lastInteraction).toBeNull();
+    expect(state.lastSelectionSource).toBeNull();
+    expect(state.lastSelectionAt).toBeNull();
   });
 
   it("updates selected and hovered ids", () => {
     const { setSelected, setHovered } = useMapSelectionStore.getState();
 
-    setSelected(123);
-    setHovered(456);
+    setSelected(123, "map");
+    setHovered(456, "map");
 
     const state = mapSelectionStore.getState();
     expect(state.selectedId).toBe(123);
     expect(state.hoveredId).toBe(456);
+    expect(state.lastInteraction).toBe("map");
+    expect(state.lastSelectionSource).toBe("map");
+    expect(state.lastSelectionAt).toBeTypeOf("number");
   });
 
   it("keeps the selected id when the same value is set", () => {
     const { setSelected } = useMapSelectionStore.getState();
 
-    setSelected(42);
+    setSelected(42, "list");
     expect(mapSelectionStore.getState().selectedId).toBe(42);
 
-    setSelected(42);
+    const before = mapSelectionStore.getState().lastSelectionAt;
+    setSelected(42, "map");
     expect(mapSelectionStore.getState().selectedId).toBe(42);
+    expect(mapSelectionStore.getState().lastSelectionSource).toBe("map");
+    expect(mapSelectionStore.getState().lastInteraction).toBe("map");
+    expect(mapSelectionStore.getState().lastSelectionAt).toBeGreaterThanOrEqual(
+      Number(before ?? 0),
+    );
   });
 
   it("clears both ids", () => {
-    useMapSelectionStore.setState({ selectedId: 1, hoveredId: 2 });
+    useMapSelectionStore.setState({
+      selectedId: 1,
+      hoveredId: 2,
+      lastInteraction: "map",
+      lastSelectionSource: "map",
+      lastSelectionAt: 123,
+    });
 
     mapSelectionStore.getState().clear();
 
     const state = mapSelectionStore.getState();
     expect(state.selectedId).toBeNull();
     expect(state.hoveredId).toBeNull();
+    expect(state.lastInteraction).toBeNull();
+    expect(state.lastSelectionSource).toBeNull();
+    expect(state.lastSelectionAt).toBeNull();
   });
 });

--- a/frontend/src/state/mapSelection.ts
+++ b/frontend/src/state/mapSelection.ts
@@ -6,23 +6,65 @@ import type { GymSummary } from "@/types/gym";
 
 type GymId = GymSummary["id"];
 
+export type MapInteractionSource = "map" | "list" | "url";
+
 interface MapSelectionState {
   selectedId: GymId | null;
   hoveredId: GymId | null;
-  setSelected: (id: GymId | null) => void;
-  setHovered: (id: GymId | null) => void;
+  lastInteraction: MapInteractionSource | null;
+  lastSelectionSource: MapInteractionSource | null;
+  lastSelectionAt: number | null;
+  setSelected: (id: GymId | null, source?: MapInteractionSource) => void;
+  setHovered: (id: GymId | null, source?: MapInteractionSource) => void;
   clear: () => void;
 }
 
 export const useMapSelectionStore = create<MapSelectionState>(set => ({
   selectedId: null,
   hoveredId: null,
-  setSelected: id =>
-    set(() => ({
-      selectedId: id ?? null,
-    })),
-  setHovered: id => set({ hoveredId: id }),
-  clear: () => set({ selectedId: null, hoveredId: null }),
+  lastInteraction: null,
+  lastSelectionSource: null,
+  lastSelectionAt: null,
+  setSelected: (id, source) =>
+    set(state => {
+      const nextSelected = id ?? null;
+      const update: Partial<MapSelectionState> = {};
+
+      if (state.selectedId !== nextSelected) {
+        update.selectedId = nextSelected;
+      }
+
+      if (source) {
+        update.lastInteraction = source;
+        update.lastSelectionSource = source;
+        update.lastSelectionAt = Date.now();
+      }
+
+      return Object.keys(update).length > 0 ? update : {};
+    }),
+  setHovered: (id, source) =>
+    set(state => {
+      const nextHovered = id ?? null;
+      const update: Partial<MapSelectionState> = {};
+
+      if (state.hoveredId !== nextHovered) {
+        update.hoveredId = nextHovered;
+      }
+
+      if (source) {
+        update.lastInteraction = source;
+      }
+
+      return Object.keys(update).length > 0 ? update : {};
+    }),
+  clear: () =>
+    set({
+      selectedId: null,
+      hoveredId: null,
+      lastInteraction: null,
+      lastSelectionSource: null,
+      lastSelectionAt: null,
+    }),
 }));
 
 export const mapSelectionStore = useMapSelectionStore;
@@ -32,5 +74,11 @@ export const resetMapSelectionStoreForTests = () => {
     return;
   }
 
-  useMapSelectionStore.setState({ selectedId: null, hoveredId: null });
+  useMapSelectionStore.setState({
+    selectedId: null,
+    hoveredId: null,
+    lastInteraction: null,
+    lastSelectionSource: null,
+    lastSelectionAt: null,
+  });
 };


### PR DESCRIPTION
## 概要
- ジム一覧のホバー／クリックに応じてマーカーのハイライトとパンを双方向に同期
- パン時のデバウンスとドラッグガードで過剰な移動を抑制
- URL クエリ `selected` と選択状態を同期し初期表示時の復元を可能に

## 変更内容
- Zustand ストアに発火元とタイムスタンプのメタ情報を追加し、操作元を判別
- リスト／マップ双方のイベントに発火元を付与してハイライト・パン制御を調整
- マップ側で低ズーム時のみズームアップし、マップ発イベント直後の再パンを抑制
- URL クエリへの選択反映と初期ロード時の復元ロジックを追加
- マップ連携のユニットテストを追加し、デバウンスやドラッグ抑制を検証

## 動作確認
- npm run lint
- npm run typecheck
- npm run test:unit
