### PR TITLE
FE8: ページネーション × 地図 × URL 同期

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { AuthProvider } from "@/auth/AuthProvider";
 import { AppHeader } from "@/components/common/Header";
 import { Toaster } from "@/components/ui/toaster";
+import { ReactQueryProvider } from "@/providers/ReactQueryProvider";
 
 import "./globals.css";
 
@@ -15,13 +16,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ja">
       <body className="bg-background font-sans text-foreground antialiased">
-        <AuthProvider>
-          <div className="flex min-h-screen flex-col">
-            <AppHeader />
-            <div className="flex-1">{children}</div>
-            <Toaster />
-          </div>
-        </AuthProvider>
+        <ReactQueryProvider>
+          <AuthProvider>
+            <div className="flex min-h-screen flex-col">
+              <AppHeader />
+              <div className="flex-1">{children}</div>
+              <Toaster />
+            </div>
+          </AuthProvider>
+        </ReactQueryProvider>
       </body>
     </html>
   );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-separator": "^1.0.5",
         "@radix-ui/react-slot": "^1.1.1",
         "@radix-ui/react-toast": "^1.1.5",
+        "@tanstack/react-query": "^5.90.2",
         "@tanstack/react-virtual": "^3.0.0",
         "@types/supercluster": "^7.1.3",
         "class-variance-authority": "^0.7.1",
@@ -3782,6 +3783,32 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-virtual": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-separator": "^1.0.5",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-toast": "^1.1.5",
+    "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-virtual": "^3.0.0",
     "@types/supercluster": "^7.1.3",
     "class-variance-authority": "^0.7.1",

--- a/frontend/src/components/gyms/MapView.tsx
+++ b/frontend/src/components/gyms/MapView.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+import type { MapViewport } from "@/hooks/useVisibleGyms";
+import { haversineDistanceKm } from "@/lib/geo";
+import { MIN_DISTANCE_KM, MAX_DISTANCE_KM } from "@/lib/searchParams";
+import type { MapInteractionSource } from "@/state/mapSelection";
+import type { NearbyGym } from "@/types/gym";
+import { useGymSearchStore, gymSearchStore } from "@/store/searchStore";
+
+const NearbyMap = dynamic(
+  () => import("@/features/gyms/nearby/components/NearbyMap").then(mod => mod.NearbyMap),
+  {
+    ssr: false,
+  },
+);
+
+const RADIUS_DEBOUNCE_MS = 300;
+
+const calculateRadius = (viewport: MapViewport): number => {
+  const { center, bounds } = viewport;
+  const northEast = { lat: bounds.north, lng: bounds.east };
+  const southWest = { lat: bounds.south, lng: bounds.west };
+  const radius = Math.max(
+    haversineDistanceKm(center, northEast),
+    haversineDistanceKm(center, southWest),
+  );
+  const clamped = Math.min(Math.max(radius, MIN_DISTANCE_KM), MAX_DISTANCE_KM);
+  return Number.isFinite(clamped) ? clamped : MIN_DISTANCE_KM;
+};
+
+interface MapViewProps {
+  markers: NearbyGym[];
+  status: "idle" | "loading" | "success" | "error";
+  error: string | null;
+  isInitialLoading: boolean;
+  onRetry?: () => void;
+}
+
+export function MapView({ markers, status, error, isInitialLoading, onRetry }: MapViewProps) {
+  const {
+    lat,
+    lng,
+    zoom,
+    selectedGymId,
+    lastSelectionSource: rawLastSelectionSource,
+    lastSelectionAt,
+  } = useGymSearchStore(state => ({
+    lat: state.lat,
+    lng: state.lng,
+    zoom: state.zoom,
+    selectedGymId: state.selectedGymId,
+    lastSelectionSource: state.lastSelectionSource,
+    lastSelectionAt: state.lastSelectionAt,
+  }));
+  const setMapState = useGymSearchStore(state => state.setMapState);
+  const setSelectedGym = useGymSearchStore(state => state.setSelectedGym);
+  const setBusyFlag = useGymSearchStore(state => state.setBusyFlag);
+
+  const lastSelectionSource: MapInteractionSource | null =
+    rawLastSelectionSource === "panel"
+      ? null
+      : rawLastSelectionSource === "url"
+        ? "url"
+        : rawLastSelectionSource;
+
+  const markersById = useMemo(() => new Map(markers.map(marker => [marker.id, marker])), [markers]);
+
+  const debounceRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      setBusyFlag("mapInteracting", false);
+    },
+    [setBusyFlag],
+  );
+
+  const handleViewportChange = useCallback(
+    (viewport: MapViewport) => {
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      const radiusKm = calculateRadius(viewport);
+      const { center, zoom: viewportZoom } = viewport;
+      const current = gymSearchStore.getState();
+      const sameCenter =
+        Math.abs(current.lat - center.lat) < 1e-6 && Math.abs(current.lng - center.lng) < 1e-6;
+      const sameRadius = Math.abs(current.radiusKm - radiusKm) < 0.05;
+      const sameZoom = viewportZoom == null ? true : Math.abs(current.zoom - viewportZoom) < 0.01;
+      if (sameCenter && sameRadius && sameZoom) {
+        return;
+      }
+      setBusyFlag("mapInteracting", true);
+      debounceRef.current = window.setTimeout(() => {
+        setBusyFlag("mapInteracting", false);
+        setMapState({ lat: center.lat, lng: center.lng, radiusKm, zoom: viewportZoom });
+      }, RADIUS_DEBOUNCE_MS);
+    },
+    [setBusyFlag, setMapState],
+  );
+
+  const handleSelect = useCallback(
+    (gymId: number | null, source: MapInteractionSource) => {
+      if (gymId == null) {
+        setSelectedGym({ slug: null, id: null, source });
+        return;
+      }
+      const gym = markersById.get(gymId) ?? null;
+      setSelectedGym({ slug: gym?.slug ?? null, id: gymId, source });
+    },
+    [markersById, setSelectedGym],
+  );
+
+  return (
+    <NearbyMap
+      center={{ lat, lng }}
+      zoom={zoom}
+      markers={markers}
+      selectedGymId={selectedGymId}
+      lastSelectionSource={lastSelectionSource}
+      lastSelectionAt={lastSelectionAt}
+      onCenterChange={center => {
+        setBusyFlag("mapInteracting", true);
+        if (debounceRef.current !== null) {
+          window.clearTimeout(debounceRef.current);
+          debounceRef.current = null;
+        }
+        const current = gymSearchStore.getState();
+        const sameCenter =
+          Math.abs(current.lat - center.lat) < 1e-6 && Math.abs(current.lng - center.lng) < 1e-6;
+        if (sameCenter) {
+          setBusyFlag("mapInteracting", false);
+          return;
+        }
+        debounceRef.current = window.setTimeout(() => {
+          setBusyFlag("mapInteracting", false);
+          setMapState({ lat: center.lat, lng: center.lng });
+        }, RADIUS_DEBOUNCE_MS);
+      }}
+      onViewportChange={handleViewportChange}
+      onSelect={handleSelect}
+      markersStatus={status}
+      markersError={error}
+      markersIsLoading={status === "loading"}
+      markersIsInitialLoading={isInitialLoading}
+      onRetryMarkers={onRetry}
+    />
+  );
+}

--- a/frontend/src/hooks/useGymDirectoryData.ts
+++ b/frontend/src/hooks/useGymDirectoryData.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useMemo } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { fetchNearbyGyms } from "@/services/gymNearby";
+import { searchGyms } from "@/services/gyms";
+import { useGymSearchStore } from "@/store/searchStore";
+import type { GymNearbyResponse, GymSearchResponse } from "@/types/gym";
+
+const MAP_RESULT_LIMIT = 200;
+
+export function useGymDirectoryData() {
+  const filters = useGymSearchStore(state => ({
+    q: state.q,
+    category: state.category,
+    lat: state.lat,
+    lng: state.lng,
+    radiusKm: state.radiusKm,
+    page: state.page,
+    limit: state.limit,
+    sort: state.sort,
+  }));
+
+  const searchKey = useMemo(
+    () => [
+      "gym-search",
+      {
+        q: filters.q,
+        category: filters.category,
+        lat: filters.lat,
+        lng: filters.lng,
+        radiusKm: filters.radiusKm,
+        page: filters.page,
+        limit: filters.limit,
+        sort: filters.sort,
+      },
+    ],
+    [filters],
+  );
+
+  const searchQuery = useQuery<GymSearchResponse>({
+    queryKey: searchKey,
+    queryFn: () =>
+      searchGyms({
+        q: filters.q || undefined,
+        categories: filters.category ? [filters.category] : undefined,
+        page: filters.page,
+        limit: filters.limit,
+        sort: filters.sort,
+        lat: filters.lat,
+        lng: filters.lng,
+        radiusKm: filters.radiusKm,
+      }),
+    placeholderData: keepPreviousData,
+  });
+
+  const mapQuery = useQuery<GymNearbyResponse>({
+    queryKey: [
+      "gym-map",
+      {
+        lat: filters.lat,
+        lng: filters.lng,
+        radiusKm: filters.radiusKm,
+      },
+    ],
+    queryFn: () =>
+      fetchNearbyGyms({
+        lat: filters.lat,
+        lng: filters.lng,
+        radiusKm: filters.radiusKm,
+        perPage: Math.max(filters.limit * 2, MAP_RESULT_LIMIT),
+        page: 1,
+      }),
+    enabled: Number.isFinite(filters.lat) && Number.isFinite(filters.lng),
+    placeholderData: keepPreviousData,
+    staleTime: 60_000,
+  });
+
+  return { searchQuery, mapQuery };
+}

--- a/frontend/src/hooks/useUrlSync.ts
+++ b/frontend/src/hooks/useUrlSync.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { buildSearchQueryString, gymSearchStore } from "@/store/searchStore";
+
+const isBrowser = () => typeof window !== "undefined";
+
+export function useUrlSync() {
+  const skipSyncRef = useRef(false);
+  const lastQueryRef = useRef<string>("");
+
+  useEffect(() => {
+    if (!isBrowser()) {
+      return;
+    }
+
+    const initialUrl = new URL(window.location.href);
+    const { hydrateFromUrl } = gymSearchStore.getState();
+    hydrateFromUrl(initialUrl);
+    lastQueryRef.current = initialUrl.searchParams.toString();
+
+    const handlePopstate = () => {
+      skipSyncRef.current = true;
+      const currentUrl = new URL(window.location.href);
+      gymSearchStore.getState().applyUrlState(currentUrl);
+      lastQueryRef.current = currentUrl.searchParams.toString();
+      skipSyncRef.current = false;
+    };
+
+    window.addEventListener("popstate", handlePopstate);
+
+    return () => {
+      window.removeEventListener("popstate", handlePopstate);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isBrowser()) {
+      return;
+    }
+
+    return gymSearchStore.subscribe(
+      state => ({
+        hydrated: state.hydrated,
+        query: buildSearchQueryString(state),
+        pendingHistory: state.pendingHistory,
+      }),
+      snapshot => {
+        if (!snapshot.hydrated) {
+          return;
+        }
+        if (skipSyncRef.current) {
+          return;
+        }
+        const pathname = window.location.pathname;
+        const query = snapshot.query;
+        if (query === lastQueryRef.current) {
+          return;
+        }
+        const url = query ? `${pathname}?${query}` : pathname;
+        if (snapshot.pendingHistory === "push") {
+          window.history.pushState(null, "", url);
+        } else {
+          window.history.replaceState(null, "", url);
+        }
+        lastQueryRef.current = query;
+        gymSearchStore.getState().markUrlSynced(query);
+      },
+    );
+  }, []);
+}

--- a/frontend/src/providers/ReactQueryProvider.tsx
+++ b/frontend/src/providers/ReactQueryProvider.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+interface ReactQueryProviderProps {
+  children: ReactNode;
+}
+
+export function ReactQueryProvider({ children }: ReactQueryProviderProps) {
+  const [client] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            retry: 1,
+            staleTime: 30_000,
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/frontend/src/store/searchStore.ts
+++ b/frontend/src/store/searchStore.ts
@@ -1,0 +1,406 @@
+"use client";
+
+import { create } from "zustand";
+import { subscribeWithSelector } from "zustand/middleware";
+
+import {
+  clampLatitude,
+  clampLongitude,
+  DEFAULT_DISTANCE_KM,
+  DEFAULT_LIMIT,
+  MAX_DISTANCE_KM,
+  MAX_LIMIT,
+  MIN_DISTANCE_KM,
+  SortOption,
+  SORT_OPTIONS,
+} from "@/lib/searchParams";
+
+const DEFAULT_CENTER = Object.freeze({
+  lat: 35.681236,
+  lng: 139.767125,
+});
+
+const DEFAULT_SORT: SortOption = "distance";
+const DEFAULT_LIMIT_VALUE = DEFAULT_LIMIT;
+const DEFAULT_RADIUS_KM = 5;
+const DEFAULT_ZOOM = 12;
+
+const logEvent = (
+  type: "page_change" | "filter_change" | "map_move",
+  payload: Record<string, unknown>,
+) => {
+  if (typeof console === "undefined" || typeof console.info !== "function") {
+    return;
+  }
+  console.info(type, payload);
+};
+
+const clampRadius = (value: number | null | undefined): number => {
+  if (value == null || Number.isNaN(value) || !Number.isFinite(value)) {
+    return DEFAULT_DISTANCE_KM;
+  }
+  const rounded = Math.round(value);
+  return Math.min(Math.max(rounded, MIN_DISTANCE_KM), MAX_DISTANCE_KM);
+};
+
+const clampPage = (value: number | null | undefined): number => {
+  if (value == null || Number.isNaN(value) || !Number.isFinite(value)) {
+    return 1;
+  }
+  const parsed = Math.trunc(value);
+  return parsed > 0 ? parsed : 1;
+};
+
+const clampLimit = (value: number | null | undefined): number => {
+  if (value == null || Number.isNaN(value) || !Number.isFinite(value)) {
+    return DEFAULT_LIMIT_VALUE;
+  }
+  const parsed = Math.trunc(value);
+  if (parsed <= 0) {
+    return DEFAULT_LIMIT_VALUE;
+  }
+  return Math.min(parsed, MAX_LIMIT);
+};
+
+const sanitizeSort = (value: string | null | undefined): SortOption => {
+  if (!value) {
+    return DEFAULT_SORT;
+  }
+  const normalized = value.trim().toLowerCase();
+  const match = SORT_OPTIONS.find(option => option === normalized);
+  return match ?? DEFAULT_SORT;
+};
+
+const parseNumber = (value: string | null): number | null => {
+  if (!value) {
+    return null;
+  }
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseQueryParams = (params: URLSearchParams): ParsedQueryParams => {
+  const q = params.get("q")?.trim() ?? "";
+  const category = params.get("category")?.trim() || "";
+  const latParam = parseNumber(params.get("lat"));
+  const lngParam = parseNumber(params.get("lng"));
+  const radiusParam = parseNumber(params.get("radius"));
+  const pageParam = parseNumber(params.get("page"));
+  const limitParam = parseNumber(params.get("limit"));
+  const sortParam = params.get("sort");
+
+  const lat = latParam == null ? DEFAULT_CENTER.lat : clampLatitude(latParam);
+  const lng = lngParam == null ? DEFAULT_CENTER.lng : clampLongitude(lngParam);
+  const radiusKm = clampRadius(radiusParam);
+  const page = clampPage(pageParam);
+  const limit = clampLimit(limitParam);
+  const sort = sanitizeSort(sortParam);
+
+  return {
+    q,
+    category,
+    lat,
+    lng,
+    radiusKm,
+    page,
+    limit,
+    sort,
+  };
+};
+
+const buildSearchParams = (state: GymSearchStoreState): URLSearchParams => {
+  const params = new URLSearchParams();
+  if (state.q.trim()) {
+    params.set("q", state.q.trim());
+  }
+  if (state.category.trim()) {
+    params.set("category", state.category.trim());
+  }
+  params.set("lat", state.lat.toFixed(6));
+  params.set("lng", state.lng.toFixed(6));
+  params.set("radius", String(state.radiusKm));
+  if (state.page > 1) {
+    params.set("page", String(state.page));
+  }
+  if (state.limit !== DEFAULT_LIMIT_VALUE) {
+    params.set("limit", String(state.limit));
+  }
+  if (state.sort !== DEFAULT_SORT) {
+    params.set("sort", state.sort);
+  }
+  return params;
+};
+
+type HistoryMode = "replace" | "push";
+
+type BusyFlags = {
+  hydrating: boolean;
+  urlSync: boolean;
+  mapInteracting: boolean;
+};
+
+type ParsedQueryParams = {
+  q: string;
+  category: string;
+  lat: number;
+  lng: number;
+  radiusKm: number;
+  page: number;
+  limit: number;
+  sort: SortOption;
+};
+
+type GymSearchStoreState = {
+  q: string;
+  category: string;
+  lat: number;
+  lng: number;
+  radiusKm: number;
+  page: number;
+  limit: number;
+  sort: SortOption;
+  zoom: number;
+  selectedGymSlug: string | null;
+  selectedGymId: number | null;
+  lastSelectionSource: "map" | "list" | "panel" | "url" | null;
+  lastSelectionAt: number | null;
+  rightPanelOpen: boolean;
+  busyFlags: BusyFlags;
+  hydrated: boolean;
+  pendingHistory: HistoryMode;
+  lastSyncedQuery: string;
+};
+
+type GymSearchStoreActions = {
+  hydrateFromUrl: (url: URL | string) => void;
+  applyUrlState: (url: URL | string) => void;
+  markUrlSynced: (query: string) => void;
+  setQuery: (value: string) => void;
+  setCategory: (value: string) => void;
+  setSort: (sort: SortOption) => void;
+  setMapState: (input: { lat: number; lng: number; radiusKm?: number; zoom?: number }) => void;
+  setPagination: (page: number, options?: { history?: HistoryMode }) => void;
+  setLimit: (limit: number) => void;
+  setSelectedGym: (payload: {
+    slug: string | null;
+    id: number | null;
+    source?: "map" | "list" | "panel" | "url";
+  }) => void;
+  setRightPanelOpen: (open: boolean) => void;
+  resetFilters: () => void;
+  resetSelectionIfMissing: (availableSlugs: Set<string>) => void;
+  setTotalPages: (totalPages: number | null) => void;
+  setBusyFlag: (key: keyof BusyFlags, value: boolean) => void;
+};
+
+type GymSearchStore = GymSearchStoreState & GymSearchStoreActions;
+
+const INITIAL_STATE: GymSearchStoreState = {
+  q: "",
+  category: "",
+  lat: DEFAULT_CENTER.lat,
+  lng: DEFAULT_CENTER.lng,
+  radiusKm: DEFAULT_RADIUS_KM,
+  page: 1,
+  limit: DEFAULT_LIMIT_VALUE,
+  sort: DEFAULT_SORT,
+  zoom: DEFAULT_ZOOM,
+  selectedGymSlug: null,
+  selectedGymId: null,
+  lastSelectionSource: null,
+  lastSelectionAt: null,
+  rightPanelOpen: false,
+  busyFlags: {
+    hydrating: false,
+    urlSync: false,
+    mapInteracting: false,
+  },
+  hydrated: false,
+  pendingHistory: "replace",
+  lastSyncedQuery: "",
+};
+
+export const useGymSearchStore = create<GymSearchStore>()(
+  subscribeWithSelector((set, get) => ({
+    ...INITIAL_STATE,
+    hydrateFromUrl: input => {
+      const url = typeof input === "string" ? new URL(input, "http://localhost") : input;
+      const params = url.searchParams;
+      const parsed = parseQueryParams(params);
+      set({
+        ...parsed,
+        zoom: get().zoom,
+        selectedGymSlug: get().selectedGymSlug,
+        selectedGymId: get().selectedGymId,
+        busyFlags: { ...get().busyFlags, hydrating: true },
+        hydrated: true,
+        pendingHistory: "replace",
+      });
+      set(state => ({
+        busyFlags: { ...state.busyFlags, hydrating: false },
+        lastSyncedQuery: buildSearchParams(state).toString(),
+      }));
+    },
+    applyUrlState: input => {
+      const url = typeof input === "string" ? new URL(input, "http://localhost") : input;
+      const params = url.searchParams;
+      const parsed = parseQueryParams(params);
+      set(state => ({
+        ...state,
+        ...parsed,
+        busyFlags: { ...state.busyFlags, urlSync: true },
+        pendingHistory: "replace",
+        hydrated: true,
+      }));
+      set(state => ({
+        busyFlags: { ...state.busyFlags, urlSync: false },
+        lastSyncedQuery: buildSearchParams(state).toString(),
+      }));
+    },
+    markUrlSynced: query => {
+      set(state => ({
+        pendingHistory: "replace",
+        lastSyncedQuery: query,
+      }));
+    },
+    setQuery: value => {
+      const next = value ?? "";
+      set(state => ({
+        q: next,
+        page: 1,
+        pendingHistory: "replace",
+      }));
+      logEvent("filter_change", { filter: "q", value: next });
+    },
+    setCategory: value => {
+      const next = typeof value === "string" ? value.trim() : "";
+      set(state => ({
+        category: next,
+        page: 1,
+        pendingHistory: "replace",
+      }));
+      logEvent("filter_change", { filter: "category", value: next });
+    },
+    setSort: sort => {
+      const next = sanitizeSort(sort);
+      set(state => ({
+        sort: next,
+        page: 1,
+        pendingHistory: "replace",
+      }));
+      logEvent("filter_change", { filter: "sort", value: next });
+    },
+    setMapState: ({ lat, lng, radiusKm, zoom }) => {
+      const sanitizedLat = clampLatitude(lat);
+      const sanitizedLng = clampLongitude(lng);
+      const sanitizedRadius = radiusKm != null ? clampRadius(radiusKm) : undefined;
+      const sanitizedZoom = zoom != null && Number.isFinite(zoom) ? zoom : undefined;
+      set(state => ({
+        lat: sanitizedLat,
+        lng: sanitizedLng,
+        radiusKm: sanitizedRadius ?? state.radiusKm,
+        zoom: sanitizedZoom ?? state.zoom,
+        page: 1,
+        pendingHistory: "replace",
+      }));
+      const state = get();
+      logEvent("map_move", {
+        lat: sanitizedLat,
+        lng: sanitizedLng,
+        radiusKm: sanitizedRadius ?? state.radiusKm,
+        zoom: sanitizedZoom ?? state.zoom,
+      });
+    },
+    setPagination: (page, options) => {
+      const nextPage = clampPage(page);
+      set(state => ({
+        page: nextPage,
+        pendingHistory: options?.history ?? "push",
+      }));
+      logEvent("page_change", { page: nextPage });
+    },
+    setLimit: limit => {
+      const sanitized = clampLimit(limit);
+      set(state => ({
+        limit: sanitized,
+        page: 1,
+        pendingHistory: "replace",
+      }));
+      logEvent("filter_change", { filter: "limit", value: sanitized });
+    },
+    setSelectedGym: ({ slug, id, source }) => {
+      set(state => ({
+        selectedGymSlug: slug ?? null,
+        selectedGymId: id ?? null,
+        rightPanelOpen: slug != null,
+        lastSelectionSource: source ?? state.lastSelectionSource,
+        lastSelectionAt: source ? Date.now() : state.lastSelectionAt,
+      }));
+    },
+    setRightPanelOpen: open => {
+      set(state => ({
+        rightPanelOpen: open,
+        pendingHistory: "replace",
+      }));
+    },
+    resetFilters: () => {
+      set(state => ({
+        q: "",
+        category: "",
+        sort: DEFAULT_SORT,
+        page: 1,
+        pendingHistory: "replace",
+      }));
+      logEvent("filter_change", { filter: "reset" });
+    },
+    resetSelectionIfMissing: availableSlugs => {
+      set(state => {
+        if (!state.selectedGymSlug) {
+          return state;
+        }
+        if (availableSlugs.has(state.selectedGymSlug)) {
+          return state;
+        }
+        return {
+          ...state,
+          selectedGymSlug: null,
+          selectedGymId: null,
+          rightPanelOpen: false,
+          lastSelectionSource: null,
+          lastSelectionAt: null,
+        };
+      });
+    },
+    setTotalPages: totalPages => {
+      if (totalPages == null || !Number.isFinite(totalPages)) {
+        return;
+      }
+      set(state => {
+        const maxPage = Math.max(1, Math.trunc(totalPages));
+        if (state.page <= maxPage) {
+          return state;
+        }
+        return {
+          ...state,
+          page: maxPage,
+          pendingHistory: "replace",
+        };
+      });
+    },
+    setBusyFlag: (key, value) => {
+      set(state => ({
+        busyFlags: {
+          ...state.busyFlags,
+          [key]: value,
+        },
+      }));
+    },
+  })),
+);
+
+export const gymSearchStore = useGymSearchStore;
+
+export const buildSearchQueryString = (state: GymSearchStoreState): string =>
+  buildSearchParams(state).toString();
+
+export type { GymSearchStoreState };


### PR DESCRIPTION
## Summary
- add a Zustand-based gym search store that hydrates from the URL, syncs map pagination/filter state, and drives history updates
- provide React Query integration and hooks/components (URL sync, directory data, map view) to hydrate the directory experience
- wire the gyms page to the new store with pagination, list/map coordination, and shared selection handling

## Testing
- pnpm lint
- pnpm typecheck
- pnpm format:check *(fails on pre-existing formatting issues outside the modified files)*

## Acceptance
- URL query params (page/limit/q/category/lat/lng/radius/sort) directly edited -> screen re-syncs and re-fetches
- Navigating through pagination then hitting browser back restores previous page, map, and filters
- Moving the map updates radius, syncs URL, and refreshes the list within that extent
- Right panel selection persists unless the gym falls outside the current page or bounds
- Skeleton shows while loading, empty state appears when no results
- No map jitter or re-render loops observed during rapid interactions

## Screenshots
![Gyms directory with URL-synced map and pagination](browser:/invocations/xtvrzvtw/artifacts/artifacts/gyms-page.png)


------
https://chatgpt.com/codex/tasks/task_e_68d64b18a19c832a9f43ad517172f50d