### PR TITLE
[Draft] refactor: URL制御リファクタリング

### DIFF
--- a/frontend/src/components/gyms/GymList.tsx
+++ b/frontend/src/components/gyms/GymList.tsx
@@ -140,6 +140,12 @@ export function GymList({
       return;
     }
 
+    if (navigationSource === "replace") {
+      setNavigationSource("idle");
+      previousPageRef.current = page;
+      return;
+    }
+
     if (previousPageRef.current !== page) {
       resultSectionRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
       resultSectionRef.current.focus();

--- a/frontend/src/hooks/useSelectedGym.ts
+++ b/frontend/src/hooks/useSelectedGym.ts
@@ -45,7 +45,31 @@ export function useSelectedGym({
   const setSelectedId = useMapSelectionStore(state => state.setSelected);
 
   const skipUrlToStoreSyncRef = useRef(false);
+  const skipStoreToUrlSyncRef = useRef(false);
+  const nextNavigationModeRef = useRef<"push" | "replace" | null>(null);
   const lastSyncedIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handlePopState = () => {
+      const params = new URLSearchParams(window.location.search);
+      const nextId = toGymId(params.get(queryKey));
+
+      skipUrlToStoreSyncRef.current = true;
+      skipStoreToUrlSyncRef.current = true;
+      nextNavigationModeRef.current = null;
+      setSelectedId(nextId, "url");
+    };
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [queryKey, setSelectedId]);
 
   useEffect(() => {
     if (skipUrlToStoreSyncRef.current) {
@@ -68,7 +92,15 @@ export function useSelectedGym({
       return;
     }
 
+    if (skipStoreToUrlSyncRef.current) {
+      skipStoreToUrlSyncRef.current = false;
+      lastSyncedIdRef.current = selectedGymId;
+      nextNavigationModeRef.current = null;
+      return;
+    }
+
     if (selectedGymId === lastSyncedIdRef.current) {
+      nextNavigationModeRef.current = null;
       return;
     }
 
@@ -78,6 +110,7 @@ export function useSelectedGym({
 
     if (next === current) {
       lastSyncedIdRef.current = selectedGymId;
+      nextNavigationModeRef.current = null;
       return;
     }
 
@@ -87,12 +120,21 @@ export function useSelectedGym({
       params.set(queryKey, next);
     }
 
-    const query = params.toString();
-    const url = query ? `${pathname}?${query}` : pathname;
+    const nextQuery = params.toString();
+    const url = nextQuery ? `${pathname}?${nextQuery}` : pathname;
+    const navigationMode =
+      nextNavigationModeRef.current ??
+      (nextQuery === searchParamsSnapshot ? "replace" : "push");
 
     skipUrlToStoreSyncRef.current = true;
     lastSyncedIdRef.current = selectedGymId;
-    router.replace(url, { scroll: false });
+    nextNavigationModeRef.current = null;
+
+    if (navigationMode === "replace") {
+      router.replace(url, { scroll: false });
+    } else {
+      router.push(url, { scroll: false });
+    }
   }, [pathname, queryKey, router, searchParamsSnapshot, selectedGymId]);
 
   useEffect(() => {
@@ -105,6 +147,8 @@ export function useSelectedGym({
     }
 
     skipUrlToStoreSyncRef.current = true;
+    skipStoreToUrlSyncRef.current = false;
+    nextNavigationModeRef.current = "replace";
     setSelectedId(null);
   }, [gyms, selectedGymId, setSelectedId]);
 
@@ -116,6 +160,8 @@ export function useSelectedGym({
   const selectGym = useCallback(
     (id: number | null, source?: MapInteractionSource) => {
       skipUrlToStoreSyncRef.current = true;
+      skipStoreToUrlSyncRef.current = false;
+      nextNavigationModeRef.current = "push";
       if (id === selectedGymId) {
         setSelectedId(null, source);
         return;
@@ -130,6 +176,8 @@ export function useSelectedGym({
       return;
     }
     skipUrlToStoreSyncRef.current = true;
+    skipStoreToUrlSyncRef.current = false;
+    nextNavigationModeRef.current = "push";
     setSelectedId(null);
   }, [selectedGymId, setSelectedId]);
 

--- a/frontend/src/store/searchStore.ts
+++ b/frontend/src/store/searchStore.ts
@@ -28,7 +28,7 @@ export const areFilterStatesEqual = (a: FilterState, b: FilterState) =>
   a.lng === b.lng &&
   areCategoriesEqual(a.categories, b.categories);
 
-export type NavigationSource = "initial" | "push" | "pop" | "idle";
+export type NavigationSource = "initial" | "push" | "pop" | "replace" | "idle";
 
 type SearchStoreState = {
   filters: FilterState;


### PR DESCRIPTION
## 概要
- `useGymSearch` の履歴更新処理を push/replace に応じた分岐へ整理し、popstate からストアへ即時反映するハンドラを追加
- `useSelectedGym` に popstate 同期と push/replace の使い分けを導入し、選択解除の履歴更新を再編成
- replace 遷移時にスクロールを保持するよう `GymList` のナビゲーション分岐を拡張

## テスト
- npm run lint --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d69928bb6c832a8cc91e2a1bba4a74