### PR TITLE
fix(frontend): ページネーションUXの安定化

### DIFF
--- a/frontend/src/components/gyms/GymList.tsx
+++ b/frontend/src/components/gyms/GymList.tsx
@@ -255,8 +255,14 @@ export function GymList({
     const hasPageChanged = previousPageRef.current !== page;
 
     if (navigationSource === "push" || navigationSource === "replace") {
-      if (hasPageChanged || navigationSource === "push") {
+      const shouldScroll = hasPageChanged || navigationSource === "push";
+      const shouldFocus = hasPageChanged;
+
+      if (shouldScroll) {
         section.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+
+      if (shouldFocus) {
         requestFocus("page");
       }
       setNavigationSource("idle");

--- a/frontend/src/components/gyms/GymList.tsx
+++ b/frontend/src/components/gyms/GymList.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  type ReactNode,
-} from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, type ReactNode } from "react";
 import dynamic from "next/dynamic";
 import type { ForwardRefExoticComponent, JSX, RefAttributes } from "react";
 
@@ -42,9 +35,7 @@ const VirtualizedGymGrid = dynamic<VirtualizedGymGridProps>(
       </div>
     ),
   },
-) as ForwardRefExoticComponent<
-  VirtualizedGymGridProps & RefAttributes<VirtualizedGymGridHandle>
->;
+) as ForwardRefExoticComponent<VirtualizedGymGridProps & RefAttributes<VirtualizedGymGridHandle>>;
 
 const escapeSelector = (value: string) => {
   if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
@@ -151,7 +142,7 @@ export function GymList({
     const targetSlug = hasSelectedOnPage
       ? selectedSlug
       : gyms.length > 0
-        ? gyms[0]?.slug ?? null
+        ? (gyms[0]?.slug ?? null)
         : null;
 
     focusRequestRef.current = null;

--- a/frontend/src/components/gyms/GymList.tsx
+++ b/frontend/src/components/gyms/GymList.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useId, useRef, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react";
 import dynamic from "next/dynamic";
-import type { JSX } from "react";
+import type { ForwardRefExoticComponent, JSX, RefAttributes } from "react";
 
 import { GymCard } from "@/components/gyms/GymCard";
 import { Pagination } from "@/components/gyms/Pagination";
@@ -13,15 +20,16 @@ import { useSearchResultState } from "@/components/search/useSearchResultState";
 import { cn } from "@/lib/utils";
 import { useSearchStore } from "@/store/searchStore";
 import type { GymSearchMeta, GymSummary } from "@/types/gym";
+import type {
+  VirtualizedGymGridHandle,
+  VirtualizedGymGridProps,
+} from "@/components/gyms/VirtualizedGymGrid";
 
 const PAGE_SIZE_OPTIONS = [10, 20, 50];
 const VIRTUALIZE_THRESHOLD = 50;
 const PREFETCH_LIMIT = 6;
 
-const VirtualizedGymGrid = dynamic<{
-  gyms: GymSummary[];
-  renderCard: (gym: GymSummary, index: number) => JSX.Element;
-}>(
+const VirtualizedGymGrid = dynamic<VirtualizedGymGridProps>(
   async () => {
     const mod = await import("@/components/gyms/VirtualizedGymGrid");
     return { default: mod.VirtualizedGymGrid };
@@ -34,7 +42,16 @@ const VirtualizedGymGrid = dynamic<{
       </div>
     ),
   },
-);
+) as ForwardRefExoticComponent<
+  VirtualizedGymGridProps & RefAttributes<VirtualizedGymGridHandle>
+>;
+
+const escapeSelector = (value: string) => {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
+  }
+  return value.replace(/["'\\]/g, match => `\\${match}`);
+};
 
 type GymListProps = {
   gyms: GymSummary[];
@@ -97,6 +114,8 @@ export function GymList({
 
   const resultSectionRef = useRef<HTMLElement | null>(null);
   const previousPageRef = useRef(page);
+  const virtualizedGridRef = useRef<VirtualizedGymGridHandle | null>(null);
+  const focusRequestRef = useRef<"page" | "pop" | null>(null);
   const headerDescriptionId = useId();
   const paginationSummaryId = useId();
 
@@ -105,8 +124,111 @@ export function GymList({
   const consumeScrollPosition = useSearchStore(state => state.consumeScrollPosition);
   const setNavigationSource = useSearchStore(state => state.setNavigationSource);
 
+  const hasSelectedOnPage = useMemo(
+    () => (selectedSlug ? gyms.some(gym => gym.slug === selectedSlug) : false),
+    [gyms, selectedSlug],
+  );
+
+  const shouldVirtualize =
+    gyms.length >= VIRTUALIZE_THRESHOLD || (totalCount ?? 0) >= VIRTUALIZE_THRESHOLD;
+
+  const flushFocusRequest = useCallback(() => {
+    const requestType = focusRequestRef.current;
+    if (!requestType) {
+      return;
+    }
+
+    if (isPageLoading || resultState.isLoading) {
+      return;
+    }
+
+    const section = resultSectionRef.current;
+    if (!section) {
+      focusRequestRef.current = null;
+      return;
+    }
+
+    const targetSlug = hasSelectedOnPage
+      ? selectedSlug
+      : gyms.length > 0
+        ? gyms[0]?.slug ?? null
+        : null;
+
+    focusRequestRef.current = null;
+
+    if (!targetSlug) {
+      section.focus({ preventScroll: requestType === "pop" });
+      return;
+    }
+
+    if (shouldVirtualize && virtualizedGridRef.current) {
+      const targetIndex = gyms.findIndex(gym => gym.slug === targetSlug);
+      if (targetIndex >= 0) {
+        virtualizedGridRef.current.scrollToIndex(targetIndex, {
+          align: hasSelectedOnPage ? "center" : "start",
+        });
+      }
+    }
+
+    const attemptFocus = (attempt = 0) => {
+      const selector = `[data-gym-slug="${escapeSelector(targetSlug)}"]`;
+      const wrapper = section.querySelector<HTMLElement>(selector);
+
+      if (wrapper) {
+        const focusable = wrapper.querySelector<HTMLElement>(
+          'a[href],button:not([disabled]),[tabindex]:not([tabindex="-1"])',
+        );
+        const element = focusable ?? wrapper;
+
+        if (requestType === "pop") {
+          element.focus({ preventScroll: true });
+        } else {
+          element.scrollIntoView({
+            block: hasSelectedOnPage ? "center" : "start",
+            behavior: "smooth",
+          });
+          requestAnimationFrame(() => element.focus({ preventScroll: true }));
+        }
+        return;
+      }
+
+      if (attempt >= 5) {
+        section.focus({ preventScroll: requestType === "pop" });
+        return;
+      }
+
+      requestAnimationFrame(() => attemptFocus(attempt + 1));
+    };
+
+    if (shouldVirtualize) {
+      requestAnimationFrame(() => requestAnimationFrame(() => attemptFocus()));
+    } else {
+      requestAnimationFrame(() => attemptFocus());
+    }
+  }, [
+    gyms,
+    hasSelectedOnPage,
+    isPageLoading,
+    resultState.isLoading,
+    selectedSlug,
+    shouldVirtualize,
+  ]);
+
+  const requestFocus = useCallback(
+    (type: "page" | "pop") => {
+      focusRequestRef.current = type;
+      flushFocusRequest();
+    },
+    [flushFocusRequest],
+  );
+
   useEffect(() => {
-    if (!resultSectionRef.current) {
+    flushFocusRequest();
+  }, [flushFocusRequest]);
+
+  useEffect(() => {
+    const section = resultSectionRef.current;
+    if (!section) {
       previousPageRef.current = page;
       return;
     }
@@ -122,39 +244,40 @@ export function GymList({
       if (typeof saved === "number" && Number.isFinite(saved)) {
         window.scrollTo({ top: saved, behavior: "auto" });
       } else {
-        resultSectionRef.current.scrollIntoView({ behavior: "auto", block: "start" });
+        section.scrollIntoView({ behavior: "auto", block: "start" });
       }
-      resultSectionRef.current.focus();
+      requestFocus("pop");
       setNavigationSource("idle");
       previousPageRef.current = page;
       return;
     }
 
-    if (navigationSource === "push") {
-      if (previousPageRef.current !== page) {
-        resultSectionRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
-        resultSectionRef.current.focus();
+    const hasPageChanged = previousPageRef.current !== page;
+
+    if (navigationSource === "push" || navigationSource === "replace") {
+      if (hasPageChanged || navigationSource === "push") {
+        section.scrollIntoView({ behavior: "smooth", block: "start" });
+        requestFocus("page");
       }
       setNavigationSource("idle");
       previousPageRef.current = page;
       return;
     }
 
-    if (navigationSource === "replace") {
-      setNavigationSource("idle");
-      previousPageRef.current = page;
-      return;
+    if (hasPageChanged) {
+      section.scrollIntoView({ behavior: "smooth", block: "start" });
+      requestFocus("page");
     }
 
-    if (previousPageRef.current !== page) {
-      resultSectionRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
-      resultSectionRef.current.focus();
-    }
     previousPageRef.current = page;
-  }, [consumeScrollPosition, currentQueryString, navigationSource, page, setNavigationSource]);
-
-  const shouldVirtualize =
-    gyms.length >= VIRTUALIZE_THRESHOLD || (totalCount ?? 0) >= VIRTUALIZE_THRESHOLD;
+  }, [
+    consumeScrollPosition,
+    currentQueryString,
+    navigationSource,
+    page,
+    requestFocus,
+    setNavigationSource,
+  ]);
 
   const renderCard = useCallback(
     (gym: GymSummary, index: number) => (
@@ -183,7 +306,7 @@ export function GymList({
       content = (
         <div className="relative">
           {shouldVirtualize ? (
-            <VirtualizedGymGrid gyms={gyms} renderCard={renderCard} />
+            <VirtualizedGymGrid ref={virtualizedGridRef} gyms={gyms} renderCard={renderCard} />
           ) : (
             <div
               className={cn(
@@ -194,13 +317,14 @@ export function GymList({
               )}
             >
               {gyms.map((gym, index) => (
-                <GymCard
-                  key={gym.id}
-                  gym={gym}
-                  prefetch={index < PREFETCH_LIMIT}
-                  onSelect={onGymSelect}
-                  isSelected={selectedSlug === gym.slug}
-                />
+                <div
+                  className="h-full"
+                  data-gym-index={index}
+                  data-gym-slug={gym.slug}
+                  key={gym.id ?? gym.slug ?? index}
+                >
+                  {renderCard(gym, index)}
+                </div>
               ))}
             </div>
           )}

--- a/frontend/src/features/gyms/nearby/NearbyGymsPage.tsx
+++ b/frontend/src/features/gyms/nearby/NearbyGymsPage.tsx
@@ -133,7 +133,7 @@ export function NearbyGymsPage() {
     lastSelectionAt,
     selectGym,
     clearSelection,
-  } = useSelectedGym({ gyms: selectionGyms });
+  } = useSelectedGym({ gyms: selectionGyms, requiredGymIds: items.map(gym => gym.id) });
   const clearStore = useMapSelectionStore(state => state.clear);
   const [isDesktop, setIsDesktop] = useState(false);
   const desktopPanelRef = useRef<HTMLDivElement | null>(null);

--- a/frontend/src/features/gyms/nearby/components/NearbyList.tsx
+++ b/frontend/src/features/gyms/nearby/components/NearbyList.tsx
@@ -105,6 +105,8 @@ export function NearbyList({
   const itemRefs = useRef(new Map<number, HTMLDivElement>());
   const virtualScrollRef = useRef<HTMLDivElement | null>(null);
   const scrollTimeoutRef = useRef<number | null>(null);
+  const previousPageRef = useRef(meta.page);
+  const pendingPageChangeRef = useRef(false);
   const shouldVirtualize = items.length > 40;
   const virtualizer = useVirtualizer({
     count: items.length,
@@ -122,6 +124,13 @@ export function NearbyList({
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (meta.page !== previousPageRef.current) {
+      previousPageRef.current = meta.page;
+      pendingPageChangeRef.current = true;
+    }
+  }, [meta.page]);
 
   useEffect(() => {
     if (shouldVirtualize) {
@@ -314,6 +323,106 @@ export function NearbyList({
     [items, onOpenDetail, onSelectGym, selectedGymId],
   );
 
+  const focusGymButton = useCallback(
+    (
+      targetId: number | null,
+      options: {
+        align?: "start" | "center";
+        behavior?: ScrollBehavior;
+        preventScroll?: boolean;
+        fallbackToFirst?: boolean;
+      } = {},
+    ) => {
+      const { align = "start", behavior = "smooth", preventScroll = false, fallbackToFirst = true } = options;
+      const container = listRef.current;
+      if (!container) {
+        return;
+      }
+
+      const ids = items.map(gym => gym.id);
+      let resolvedId = targetId != null ? targetId : null;
+
+      if ((resolvedId == null || !ids.includes(resolvedId)) && fallbackToFirst) {
+        resolvedId = ids[0] ?? null;
+      }
+
+      if (resolvedId == null) {
+        container.focus({ preventScroll: true });
+        return;
+      }
+
+      const selector = `[data-gym-id="${resolvedId}"] button`;
+
+      const attemptFocus = (attempt = 0) => {
+        const element = container.querySelector<HTMLElement>(selector);
+        if (element) {
+          if (!preventScroll) {
+            element.scrollIntoView({ block: align, behavior });
+          }
+          element.focus({ preventScroll: preventScroll || behavior === "auto" });
+          return;
+        }
+
+        if (attempt >= 5) {
+          container.focus({ preventScroll: true });
+          return;
+        }
+
+        requestAnimationFrame(() => attemptFocus(attempt + 1));
+      };
+
+      attemptFocus();
+    },
+    [items],
+  );
+
+  useEffect(() => {
+    if (!pendingPageChangeRef.current) {
+      return;
+    }
+    if (isLoading) {
+      return;
+    }
+
+    pendingPageChangeRef.current = false;
+
+    const ids = items.map(gym => gym.id);
+    const hasSelected = selectedGymId != null && ids.includes(selectedGymId);
+    const targetId = hasSelected ? selectedGymId : ids[0] ?? null;
+    const align = hasSelected ? "center" : "start";
+
+    if (shouldVirtualize) {
+      if (targetId != null) {
+        const index = ids.indexOf(targetId);
+        if (index >= 0) {
+          requestAnimationFrame(() => {
+            virtualizer.scrollToIndex(index, { align });
+            requestAnimationFrame(() =>
+              focusGymButton(targetId, { align, fallbackToFirst: false }),
+            );
+          });
+          return;
+        }
+      }
+
+      requestAnimationFrame(() => focusGymButton(targetId, { align }));
+      return;
+    }
+
+    if (listRef.current) {
+      listRef.current.scrollTo({ top: 0, behavior: "smooth" });
+    }
+
+    requestAnimationFrame(() => focusGymButton(targetId, { align }));
+  }, [
+    focusGymButton,
+    isLoading,
+    items,
+    selectedGymId,
+    shouldVirtualize,
+    virtualizer,
+  ]);
+
   if (isInitialLoading) {
     return <NearbySkeleton />;
   }
@@ -402,6 +511,7 @@ export function NearbyList({
                   <div
                     aria-selected={isSelected}
                     className="mb-3 last:mb-0"
+                    data-gym-id={gym.id}
                     data-testid={`gym-item-${gym.id}`}
                     id={`gym-option-${gym.id}`}
                     role="option"
@@ -432,6 +542,7 @@ export function NearbyList({
               <div
                 aria-selected={isSelected}
                 className="mb-3 last:mb-0"
+                data-gym-id={gym.id}
                 data-testid={`gym-item-${gym.id}`}
                 id={`gym-option-${gym.id}`}
                 key={gym.id}

--- a/frontend/src/features/gyms/nearby/components/NearbyList.tsx
+++ b/frontend/src/features/gyms/nearby/components/NearbyList.tsx
@@ -333,7 +333,12 @@ export function NearbyList({
         fallbackToFirst?: boolean;
       } = {},
     ) => {
-      const { align = "start", behavior = "smooth", preventScroll = false, fallbackToFirst = true } = options;
+      const {
+        align = "start",
+        behavior = "smooth",
+        preventScroll = false,
+        fallbackToFirst = true,
+      } = options;
       const container = listRef.current;
       if (!container) {
         return;
@@ -388,7 +393,7 @@ export function NearbyList({
 
     const ids = items.map(gym => gym.id);
     const hasSelected = selectedGymId != null && ids.includes(selectedGymId);
-    const targetId = hasSelected ? selectedGymId : ids[0] ?? null;
+    const targetId = hasSelected ? selectedGymId : (ids[0] ?? null);
     const align = hasSelected ? "center" : "start";
 
     if (shouldVirtualize) {
@@ -414,14 +419,7 @@ export function NearbyList({
     }
 
     requestAnimationFrame(() => focusGymButton(targetId, { align }));
-  }, [
-    focusGymButton,
-    isLoading,
-    items,
-    selectedGymId,
-    shouldVirtualize,
-    virtualizer,
-  ]);
+  }, [focusGymButton, isLoading, items, selectedGymId, shouldVirtualize, virtualizer]);
 
   if (isInitialLoading) {
     return <NearbySkeleton />;


### PR DESCRIPTION
## 目的
- /gyms/search と /gyms/nearby のページネーション時のフォーカス制御とスクロール復帰を安定化する

## 変更点
- GymList にフォーカス制御と scrollIntoView の調整を追加し、仮想リストに合わせたハンドルを実装
- VirtualizedGymGrid を forwardRef 化して scrollToIndex を提供し、データ属性で選択要素を特定できるように更新
- NearbyList にページ遷移後のスクロール復帰とフォーカス維持ロジックを追加し、DOM 属性を拡張
- useSelectedGym でページに存在しない選択ジムを解除するよう必須 ID を追跡する処理を追加

## テスト方法
- `npm run lint`
- `npm run typecheck`
- `CI=1 npm run build`

## 回帰確認
- /gyms/search と /gyms/nearby の仮想スクロール描画

------
https://chatgpt.com/codex/tasks/task_e_68d6bdd56ae4832abf01dc527f28e36d