### PR TITLE
fix: ジム詳細APIの設備情報を補完

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,7 +1,7 @@
 # app/schemas.py
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 # --- 共通 ---
 
@@ -84,6 +84,14 @@ class EquipmentRow(BaseModel):
     max_weight_kg: int | None = None
     verification_status: str
     last_verified_at: datetime | None = None
+
+    @computed_field(return_type=str)
+    def name(self) -> str:
+        return self.equipment_name
+
+    @computed_field(return_type=str)
+    def slug(self) -> str:
+        return self.equipment_slug
 
 
 class SourceRow(BaseModel):

--- a/tests/test_gym_detail.py
+++ b/tests/test_gym_detail.py
@@ -33,4 +33,6 @@ async def test_gym_detail_fields(session):
         assert body["city"] == "chiyoda"
         eq = body["equipments"][0]
         assert eq["equipment_slug"] == "smith-machine"
+        assert eq["slug"] == "smith-machine"
+        assert eq["name"] == "Smith Machine"
         assert "count" in eq and "max_weight_kg" in eq


### PR DESCRIPTION
## 目的
- ジム詳細APIで設備一覧が表示されない問題を解消する

## 変更点
- legacy の設備スキーマに name/slug の算出フィールドを追加
- APIレスポンスに追加されたフィールドを検証するテストを更新

## 確認手順
- [ ] ローカルでの起動確認
- [ ] lint / format / test 実行結果

## CI
- [ ] GitHub Actions が全て成功

------
https://chatgpt.com/codex/tasks/task_e_68db98c42e98832aacb40bcb4a962ade