### PR TITLE
feat: ingest CLI のダミーパイプラインを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,13 @@ pre-commit-install:
 
 pre-commit-run:
 	pre-commit run --all-files
+
+.PHONY: ingest-fetch ingest-parse ingest-normalize ingest-approve
+ingest-fetch:
+	python -m scripts.ingest fetch --source dummy --limit 10
+ingest-parse:
+	python -m scripts.ingest parse --source dummy --limit 10
+ingest-normalize:
+	python -m scripts.ingest normalize --source dummy --limit 10
+ingest-approve:
+	python -m scripts.ingest approve --candidate-id 1 --dry-run

--- a/scripts/ingest/__init__.py
+++ b/scripts/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""CLI utilities for the ingest pipeline."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/scripts/ingest/__main__.py
+++ b/scripts/ingest/__main__.py
@@ -1,0 +1,6 @@
+"""Module entrypoint for ``python -m scripts.ingest``."""
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - CLI dispatch
+    raise SystemExit(main())

--- a/scripts/ingest/approve.py
+++ b/scripts/ingest/approve.py
@@ -1,0 +1,35 @@
+"""Dummy approval command for gym candidates."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from app.db import SessionLocal
+from app.models.gym_candidate import GymCandidate
+
+logger = logging.getLogger(__name__)
+
+
+async def approve_candidate(candidate_id: int, dry_run: bool) -> int:
+    """Log candidate information as a placeholder for approval logic."""
+    async with SessionLocal() as session:
+        candidate = await session.get(GymCandidate, candidate_id)
+        if candidate is None:
+            logger.error("Candidate %s not found", candidate_id)
+            return 1
+
+        payload = json.dumps(candidate.parsed_json or {}, ensure_ascii=False)
+        logger.info(
+            "Candidate %s summary: name='%s', pref='%s', city='%s', payload=%s",
+            candidate.id,
+            candidate.name_raw,
+            candidate.pref_slug,
+            candidate.city_slug,
+            payload,
+        )
+        if dry_run:
+            logger.info("Dry-run mode: no approval action taken")
+        else:
+            logger.info("TODO: implement approval logic (gyms/gym_equipments upsert)")
+    return 0

--- a/scripts/ingest/cli.py
+++ b/scripts/ingest/cli.py
@@ -1,0 +1,111 @@
+"""Command line interface for the ingest pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Sequence
+
+from .approve import approve_candidate
+from .fetch import fetch_pages
+from .normalize import normalize_candidates
+from .parse import parse_pages
+
+logger = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Ingest pipeline utilities")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    fetch_parser = subparsers.add_parser("fetch", help="Fetch pages for a source")
+    fetch_parser.add_argument("--source", required=True, help="Source identifier")
+    fetch_parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Number of items to process",
+    )
+    fetch_parser.add_argument(
+        "--file",
+        type=Path,
+        default=None,
+        help="Path to a file that contains URLs (one per line)",
+    )
+
+    parse_parser = subparsers.add_parser("parse", help="Parse scraped pages into candidates")
+    parse_parser.add_argument("--source", required=True, help="Source identifier")
+    parse_parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Number of items to process",
+    )
+
+    normalize_parser = subparsers.add_parser(
+        "normalize", help="Normalize parsed gym candidate records"
+    )
+    normalize_parser.add_argument("--source", required=True, help="Source identifier")
+    normalize_parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Number of items to process",
+    )
+
+    approve_parser = subparsers.add_parser(
+        "approve", help="Approve a gym candidate (dummy implementation)"
+    )
+    approve_parser.add_argument(
+        "--candidate-id",
+        required=True,
+        type=int,
+        help="Candidate identifier to approve",
+    )
+    approve_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run approval without mutating the database",
+    )
+
+    return parser
+
+
+async def _run_async_command(
+    func: Callable[..., Awaitable[int]], *args, **kwargs
+) -> int:
+    return await func(*args, **kwargs)
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    command = args.command
+    if command == "fetch":
+        return asyncio.run(_run_async_command(fetch_pages, args.source, args.limit, args.file))
+    if command == "parse":
+        return asyncio.run(_run_async_command(parse_pages, args.source, args.limit))
+    if command == "normalize":
+        return asyncio.run(_run_async_command(normalize_candidates, args.source, args.limit))
+    if command == "approve":
+        return asyncio.run(
+            _run_async_command(approve_candidate, args.candidate_id, args.dry_run)
+        )
+    msg = f"Unknown command: {command}"
+    raise ValueError(msg)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return _dispatch(args)
+    except Exception:  # pragma: no cover - CLI entry point safeguard
+        logger.exception("Ingest command failed")
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/ingest/cli.py
+++ b/scripts/ingest/cli.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
-from typing import Sequence
 
 from .approve import approve_candidate
 from .fetch import fetch_pages
@@ -74,9 +73,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-async def _run_async_command(
-    func: Callable[..., Awaitable[int]], *args, **kwargs
-) -> int:
+async def _run_async_command(func: Callable[..., Awaitable[int]], *args, **kwargs) -> int:
     return await func(*args, **kwargs)
 
 
@@ -89,9 +86,7 @@ def _dispatch(args: argparse.Namespace) -> int:
     if command == "normalize":
         return asyncio.run(_run_async_command(normalize_candidates, args.source, args.limit))
     if command == "approve":
-        return asyncio.run(
-            _run_async_command(approve_candidate, args.candidate_id, args.dry_run)
-        )
+        return asyncio.run(_run_async_command(approve_candidate, args.candidate_id, args.dry_run))
     msg = f"Unknown command: {command}"
     raise ValueError(msg)
 

--- a/scripts/ingest/fetch.py
+++ b/scripts/ingest/fetch.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from sqlalchemy import select
@@ -50,7 +50,7 @@ async def fetch_pages(source: str, limit: int | None, file_path: Path | None) ->
         )
         existing_pages = {page.url: page for page in result.scalars()}
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         created = 0
         updated = 0
         for idx, url in enumerate(urls, start=1):
@@ -77,7 +77,7 @@ async def fetch_pages(source: str, limit: int | None, file_path: Path | None) ->
     total = created + updated
     preview = ", ".join(urls[:3])
     logger.info(
-        "Upserted %s scraped pages (created=%s, updated=%s) for source '%s'", 
+        "Upserted %s scraped pages (created=%s, updated=%s) for source '%s'",
         total,
         created,
         updated,

--- a/scripts/ingest/fetch.py
+++ b/scripts/ingest/fetch.py
@@ -1,0 +1,87 @@
+"""Dummy fetch implementation that seeds ``scraped_pages`` records."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import select
+
+from app.db import SessionLocal
+from app.models.scraped_page import ScrapedPage
+
+from .utils import get_or_create_source
+
+logger = logging.getLogger(__name__)
+
+
+def _generate_dummy_urls(limit: int) -> list[str]:
+    return [f"https://example.local/gym/{i:03d}" for i in range(1, limit + 1)]
+
+
+def _load_urls_from_file(file_path: Path, limit: int | None) -> list[str]:
+    lines = [line.strip() for line in file_path.read_text().splitlines() if line.strip()]
+    if limit is not None:
+        return lines[:limit]
+    return lines
+
+
+async def fetch_pages(source: str, limit: int | None, file_path: Path | None) -> int:
+    """Fetch (dummy) HTML pages and upsert into ``scraped_pages``."""
+    limit = limit or 10
+    if file_path is not None:
+        urls = _load_urls_from_file(file_path, limit)
+    else:
+        urls = _generate_dummy_urls(limit)
+
+    if not urls:
+        logger.info("No URLs provided; nothing to fetch")
+        return 0
+
+    async with SessionLocal() as session:
+        source_obj = await get_or_create_source(session, title=source)
+
+        result = await session.execute(
+            select(ScrapedPage).where(
+                ScrapedPage.source_id == source_obj.id,
+                ScrapedPage.url.in_(urls),
+            )
+        )
+        existing_pages = {page.url: page for page in result.scalars()}
+
+        now = datetime.now(timezone.utc)
+        created = 0
+        updated = 0
+        for idx, url in enumerate(urls, start=1):
+            raw_html = f"<html><title>Dummy Gym {idx:03d}</title></html>"
+            if url in existing_pages:
+                page = existing_pages[url]
+                page.fetched_at = now
+                page.raw_html = raw_html
+                updated += 1
+                continue
+
+            page = ScrapedPage(
+                source_id=source_obj.id,
+                url=url,
+                fetched_at=now,
+                raw_html=raw_html,
+                http_status=None,
+            )
+            session.add(page)
+            created += 1
+
+        await session.commit()
+
+    total = created + updated
+    preview = ", ".join(urls[:3])
+    logger.info(
+        "Upserted %s scraped pages (created=%s, updated=%s) for source '%s'", 
+        total,
+        created,
+        updated,
+        source,
+    )
+    logger.info("Sample URLs: %s%s", preview, "..." if len(urls) > 3 else "")
+    return 0

--- a/scripts/ingest/normalize.py
+++ b/scripts/ingest/normalize.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable
+from collections.abc import Iterable
 
 from sqlalchemy import select
 
@@ -61,9 +61,7 @@ async def normalize_candidates(source: str, limit: int | None) -> int:
             logger.info("No gym candidates found for source '%s'", source)
             return 0
 
-        equipment_slugs = set(
-            (await session.execute(select(Equipment.slug))).scalars().all()
-        )
+        equipment_slugs = set((await session.execute(select(Equipment.slug))).scalars().all())
 
         updated = 0
         for candidate in candidates:

--- a/scripts/ingest/normalize.py
+++ b/scripts/ingest/normalize.py
@@ -1,0 +1,109 @@
+"""Normalize dummy gym candidate records."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from sqlalchemy import select
+
+from app.db import SessionLocal
+from app.models.equipment import Equipment
+from app.models.gym_candidate import GymCandidate
+from app.models.scraped_page import ScrapedPage
+
+from .utils import get_or_create_source
+
+logger = logging.getLogger(__name__)
+
+_PREF_MAP = {
+    "東京都": "tokyo",
+    "大阪府": "osaka",
+    "北海道": "hokkaido",
+}
+_CITY_MAP = {
+    "江東区": "koto",
+    "大阪市北区": "osaka-kita",
+    "札幌市中央区": "sapporo-chuo",
+}
+
+
+def _find_slug(address: str | None, mapping: dict[str, str]) -> str | None:
+    if not address:
+        return None
+    for keyword, slug in mapping.items():
+        if keyword in address:
+            return slug
+    return None
+
+
+def _filter_equipments(valid_slugs: Iterable[str], equipments: Iterable[str]) -> list[str]:
+    valid = set(valid_slugs)
+    return [slug for slug in equipments if slug in valid]
+
+
+async def normalize_candidates(source: str, limit: int | None) -> int:
+    """Normalize address and parsed payloads for gym candidates."""
+    async with SessionLocal() as session:
+        source_obj = await get_or_create_source(session, title=source)
+
+        candidate_query = (
+            select(GymCandidate)
+            .join(ScrapedPage, GymCandidate.source_page_id == ScrapedPage.id)
+            .where(ScrapedPage.source_id == source_obj.id)
+            .order_by(GymCandidate.id)
+        )
+        if limit is not None:
+            candidate_query = candidate_query.limit(limit)
+
+        candidates = (await session.execute(candidate_query)).scalars().all()
+        if not candidates:
+            logger.info("No gym candidates found for source '%s'", source)
+            return 0
+
+        equipment_slugs = set(
+            (await session.execute(select(Equipment.slug))).scalars().all()
+        )
+
+        updated = 0
+        for candidate in candidates:
+            pref_slug = _find_slug(candidate.address_raw, _PREF_MAP)
+            city_slug = _find_slug(candidate.address_raw, _CITY_MAP)
+
+            changed = False
+            if candidate.pref_slug != pref_slug:
+                candidate.pref_slug = pref_slug
+                changed = True
+            if candidate.city_slug != city_slug:
+                candidate.city_slug = city_slug
+                changed = True
+
+            current_json = candidate.parsed_json or {}
+            if isinstance(current_json, dict):
+                equipments = current_json.get("equipments", [])
+            else:
+                equipments = []
+            filtered = _filter_equipments(equipment_slugs, equipments)
+            if filtered != equipments:
+                new_payload = dict(current_json)
+                new_payload["equipments"] = filtered
+                candidate.parsed_json = new_payload
+                changed = True
+
+            if changed:
+                updated += 1
+
+        await session.commit()
+
+    sample_updates = [
+        f"id={candidate.id}: pref={candidate.pref_slug}, city={candidate.city_slug}"
+        for candidate in candidates[:3]
+    ]
+    if sample_updates:
+        logger.info(
+            "Sample normalized candidates: %s%s",
+            "; ".join(sample_updates),
+            "..." if len(candidates) > 3 else "",
+        )
+    logger.info("Normalized %s candidate records", updated)
+    return 0

--- a/scripts/ingest/parse.py
+++ b/scripts/ingest/parse.py
@@ -1,0 +1,127 @@
+"""Parse dummy HTML into ``gym_candidates`` records."""
+
+from __future__ import annotations
+
+import logging
+import re
+from itertools import cycle
+from typing import Any
+from urllib.parse import urlparse
+
+from sqlalchemy import select
+
+from app.db import SessionLocal
+from app.models.gym_candidate import CandidateStatus, GymCandidate
+from app.models.scraped_page import ScrapedPage
+
+from .utils import get_or_create_source
+
+logger = logging.getLogger(__name__)
+
+_TITLE_RE = re.compile(r"<title>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_ADDRESS_POOL = (
+    "東京都江東区豊洲1-1-1",
+    "大阪府大阪市北区梅田1-1-1",
+    "北海道札幌市中央区北1条西1丁目",
+)
+_EQUIPMENT_PATTERNS = (
+    ["smith-machine", "bench-press"],
+    ["squat-rack", "dumbbell"],
+)
+
+
+def _extract_name(raw_html: str | None, url: str) -> str:
+    if raw_html:
+        match = _TITLE_RE.search(raw_html)
+        if match:
+            title = match.group(1).strip()
+            if title:
+                return title
+    parsed = urlparse(url)
+    slug = parsed.path.rstrip("/").split("/")[-1]
+    return slug.replace("-", " ").replace("_", " ").title() or "Unnamed Gym"
+
+
+async def parse_pages(source: str, limit: int | None) -> int:
+    """Create or update ``gym_candidates`` from scraped pages."""
+    async with SessionLocal() as session:
+        source_obj = await get_or_create_source(session, title=source)
+
+        query = (
+            select(ScrapedPage)
+            .where(ScrapedPage.source_id == source_obj.id)
+            .order_by(ScrapedPage.fetched_at.desc())
+        )
+        if limit is not None:
+            query = query.limit(limit)
+
+        pages = (await session.execute(query)).scalars().all()
+        if not pages:
+            logger.info("No scraped pages available for source '%s'", source)
+            return 0
+
+        page_ids = [page.id for page in pages]
+        existing_candidates = {}
+        if page_ids:
+            result = await session.execute(
+                select(GymCandidate).where(GymCandidate.source_page_id.in_(page_ids))
+            )
+            existing_candidates = {
+                candidate.source_page_id: candidate
+                for candidate in result.scalars()
+            }
+
+        created = 0
+        updated = 0
+        address_iter = cycle(_ADDRESS_POOL)
+        equipment_iter = cycle(_EQUIPMENT_PATTERNS)
+        for page in pages:
+            name_raw = _extract_name(page.raw_html, page.url)
+            address_raw = next(address_iter)
+            equipments = next(equipment_iter)
+            parsed_json: dict[str, Any] = {"equipments": equipments}
+
+            candidate = existing_candidates.get(page.id)
+            if candidate is None:
+                candidate = GymCandidate(
+                    source_page_id=page.id,
+                    name_raw=name_raw,
+                    address_raw=address_raw,
+                    parsed_json=parsed_json,
+                    status=CandidateStatus.new,
+                )
+                session.add(candidate)
+                created += 1
+                continue
+
+            has_change = False
+            if candidate.name_raw != name_raw:
+                candidate.name_raw = name_raw
+                has_change = True
+            if candidate.address_raw != address_raw:
+                candidate.address_raw = address_raw
+                has_change = True
+            if candidate.parsed_json != parsed_json:
+                candidate.parsed_json = parsed_json
+                has_change = True
+            if has_change:
+                updated += 1
+
+        await session.commit()
+
+    total = created + updated
+    sample_names = ", ".join(
+        [
+            _extract_name(page.raw_html, page.url)
+            for page in pages[:3]
+        ]
+    )
+    logger.info(
+        "Processed %s scraped pages into candidates (created=%s, updated=%s)",
+        total,
+        created,
+        updated,
+    )
+    if sample_names:
+        logger.info("Sample candidate names: %s%s", sample_names, "..." if len(pages) > 3 else "")
+    return 0

--- a/scripts/ingest/parse.py
+++ b/scripts/ingest/parse.py
@@ -67,8 +67,7 @@ async def parse_pages(source: str, limit: int | None) -> int:
                 select(GymCandidate).where(GymCandidate.source_page_id.in_(page_ids))
             )
             existing_candidates = {
-                candidate.source_page_id: candidate
-                for candidate in result.scalars()
+                candidate.source_page_id: candidate for candidate in result.scalars()
             }
 
         created = 0
@@ -110,12 +109,7 @@ async def parse_pages(source: str, limit: int | None) -> int:
         await session.commit()
 
     total = created + updated
-    sample_names = ", ".join(
-        [
-            _extract_name(page.raw_html, page.url)
-            for page in pages[:3]
-        ]
-    )
+    sample_names = ", ".join([_extract_name(page.raw_html, page.url) for page in pages[:3]])
     logger.info(
         "Processed %s scraped pages into candidates (created=%s, updated=%s)",
         total,

--- a/scripts/ingest/utils.py
+++ b/scripts/ingest/utils.py
@@ -1,0 +1,37 @@
+"""Utility helpers shared across ingest commands."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.source import Source, SourceType
+
+logger = logging.getLogger(__name__)
+
+
+async def get_or_create_source(
+    session: AsyncSession,
+    *,
+    title: str,
+    source_type: SourceType = SourceType.user_submission,
+) -> Source:
+    """Retrieve an existing source or create a new one."""
+    result = await session.execute(
+        select(Source).where(
+            Source.source_type == source_type,
+            Source.title == title,
+        )
+    )
+    source = result.scalar_one_or_none()
+    if source is not None:
+        return source
+
+    source = Source(source_type=source_type, title=title)
+    session.add(source)
+    await session.commit()
+    await session.refresh(source)
+    logger.info("Created new source '%s' (%s)", title, source_type.value)
+    return source


### PR DESCRIPTION
## 目的
- scripts/ingest に CLI を追加し、ダミーの fetch/parse/normalize/approve パイプラインを流せるようにする

## 変更点
- python -m scripts.ingest で利用する CLI と各サブコマンドのダミー実装を追加
- ScrapedPage / GymCandidate を使った fetch / parse / normalize / approve の骨子を実装
- Makefile に ingest 系コマンドを追加

## 確認手順
- [ ] alembic upgrade head
- [ ] python -m scripts.ingest fetch --source dummy --limit 10
- [ ] python -m scripts.ingest parse --source dummy --limit 10
- [ ] python -m scripts.ingest normalize --source dummy --limit 10
- [ ] python -m scripts.ingest approve --candidate-id 1 --dry-run

## CI
- [ ] GitHub Actions が全て成功

------
https://chatgpt.com/codex/tasks/task_e_68dbca1476b4832abd3090c3806bfc92