### PR TITLE
fix: scraped_pages.response_meta カラム追加 DDL を冪等化

### DIFF
--- a/migrations/versions/c5f2d68f2b31_add_response_meta_to_scraped_pages.py
+++ b/migrations/versions/c5f2d68f2b31_add_response_meta_to_scraped_pages.py
@@ -7,9 +7,7 @@ Create Date: 2025-10-01 10:00:00.000000
 
 from collections.abc import Sequence
 
-import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "c5f2d68f2b31"
@@ -19,11 +17,14 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "scraped_pages",
-        sa.Column("response_meta", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    op.execute(
+        "ALTER TABLE scraped_pages "
+        "ADD COLUMN IF NOT EXISTS response_meta JSONB",
     )
 
 
 def downgrade() -> None:
-    op.drop_column("scraped_pages", "response_meta")
+    op.execute(
+        "ALTER TABLE scraped_pages "
+        "DROP COLUMN IF EXISTS response_meta",
+    )


### PR DESCRIPTION
## 目的
- `scraped_pages.response_meta` カラムが既に存在する環境でマイグレーションが失敗する問題を解消する

## 変更点
- マイグレーションで `ALTER TABLE ... ADD/DROP COLUMN IF (NOT) EXISTS` を使用し、DDL を冪等化

## 確認手順
- [ ] ローカルでの起動確認
- [ ] lint / format / test 実行結果
  - docker compose が利用できない環境のため実行できず

## CI
- [ ] GitHub Actions が全て成功

------
https://chatgpt.com/codex/tasks/task_e_68dd0c1fe968832aab02adb134b9fb92