### PR TITLE
feat: 江東区スポーツ施設サイトのインポート対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,9 @@ pre-commit-run:
 .PHONY: ingest-fetch ingest-parse ingest-normalize ingest-approve \
         ingest-fetch-site-a ingest-parse-site-a ingest-normalize-site-a \
         ingest-fetch-http-site-a-koto ingest-fetch-http-site-a-funabashi \
-        ingest-parse-site-a-funabashi ingest-normalize-site-a-funabashi
+        ingest-parse-site-a-funabashi ingest-normalize-site-a-funabashi \
+        ingest-fetch-municipal-koto ingest-parse-municipal-koto \
+        ingest-normalize-municipal-koto
 ingest-fetch:
         python -m scripts.ingest fetch --source dummy --limit 10
 ingest-parse:
@@ -77,6 +79,21 @@ ingest-normalize-site-a:
         python -m scripts.ingest normalize --source site_a --limit 10
 ingest-normalize-site-a-funabashi:
         python -m scripts.ingest normalize --source site_a --limit 10
+
+ingest-fetch-municipal-koto:
+        python -m scripts.ingest fetch-http \
+                --source municipal_koto \
+                --pref tokyo \
+                --city koto \
+                --limit 10 \
+                --min-delay 2 \
+                --max-delay 4
+
+ingest-parse-municipal-koto:
+        python -m scripts.ingest parse --source municipal_koto --limit 10
+
+ingest-normalize-municipal-koto:
+        python -m scripts.ingest normalize --source municipal_koto --limit 10
 
 curl-admin-candidates:
         @echo "# 一覧"

--- a/Makefile
+++ b/Makefile
@@ -85,15 +85,13 @@ ingest-fetch-municipal-koto:
                 --source municipal_koto \
                 --pref tokyo \
                 --city koto \
-                --limit 10 \
-                --min-delay 2 \
-                --max-delay 4
+                --limit 6
 
 ingest-parse-municipal-koto:
-        python -m scripts.ingest parse --source municipal_koto --limit 10
+        python -m scripts.ingest parse --source municipal_koto --limit 6
 
 ingest-normalize-municipal-koto:
-        python -m scripts.ingest normalize --source municipal_koto --limit 10
+        python -m scripts.ingest normalize --source municipal_koto --limit 6
 
 curl-admin-candidates:
         @echo "# 一覧"

--- a/frontend/app/gyms/[slug]/GymDetailPage.tsx
+++ b/frontend/app/gyms/[slug]/GymDetailPage.tsx
@@ -13,6 +13,7 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useToast } from "@/components/ui/use-toast";
 import { ApiError, apiRequest } from "@/lib/apiClient";
+import { encodeOnce } from "@/lib/url";
 import type {
   GymDetailApiResponse,
   GymEquipmentDetailApiResponse,
@@ -323,7 +324,7 @@ const normalizeGymDetail = (data: GymDetailApiResponse): NormalizedGymDetail => 
 };
 
 async function fetchGymDetail(slug: string, signal?: AbortSignal): Promise<NormalizedGymDetail> {
-  const response = await apiRequest<GymDetailApiResponse>(`/gyms/${encodeURIComponent(slug)}`, {
+  const response = await apiRequest<GymDetailApiResponse>(`/gyms/${encodeOnce(slug)}`, {
     method: "GET",
     signal,
   });

--- a/frontend/app/gyms/[slug]/report/ReportGymForm.tsx
+++ b/frontend/app/gyms/[slug]/report/ReportGymForm.tsx
@@ -259,7 +259,7 @@ export function ReportGymForm({ slug, gymName }: ReportGymFormProps) {
         title: "報告を受け付けました",
         description: "ご協力ありがとうございます。内容を確認いたします。",
       });
-      router.replace(`/gyms/${encodeURIComponent(slug)}`);
+      router.replace(`/gyms/${slug}`);
     } catch (error) {
       if (error instanceof ApiError) {
         const parsed = parseApiError(error);
@@ -317,7 +317,7 @@ export function ReportGymForm({ slug, gymName }: ReportGymFormProps) {
       <div className="space-y-8">
         <div className="space-y-2">
           <Link
-            href={`/gyms/${encodeURIComponent(slug)}`}
+            href={`/gyms/${slug}`}
             className="inline-flex items-center text-sm font-medium text-muted-foreground hover:text-foreground"
             aria-label="ジム詳細ページへ戻る"
           >

--- a/frontend/components/gym/ReportIssueButton.tsx
+++ b/frontend/components/gym/ReportIssueButton.tsx
@@ -18,7 +18,7 @@ interface ReportIssueButtonProps {
 }
 
 export function ReportIssueButton({ slug, gymName }: ReportIssueButtonProps) {
-  const reportUrl = `/gyms/${encodeURIComponent(slug)}/report`;
+  const reportUrl = `/gyms/${slug}/report`;
 
   return (
     <Dialog>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,3 +1,5 @@
+import { encodeOnce } from "@/lib/url";
+
 export type SearchParams = {
   pref?: string;
   city?: string;
@@ -72,7 +74,7 @@ export async function searchGyms(params: SearchParams): Promise<SearchResponse> 
 }
 
 export async function getGymBySlug(slug: string): Promise<GymDetail> {
-  return fetchJson<GymDetail>(`/gyms/${encodeURIComponent(slug)}`);
+  return fetchJson<GymDetail>(`/gyms/${encodeOnce(slug)}`);
 }
 
 // Nearby gyms (by geolocation)

--- a/frontend/lib/url.ts
+++ b/frontend/lib/url.ts
@@ -1,0 +1,1 @@
+export * from "../src/lib/url";

--- a/frontend/src/lib/__tests__/url.test.ts
+++ b/frontend/src/lib/__tests__/url.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { encodeOnce } from "@/lib/url";
+
+describe("encodeOnce", () => {
+  it("encodes plain slugs containing multibyte characters", () => {
+    const slug = "有明ジム";
+    expect(encodeOnce(slug)).toBe(encodeURIComponent(slug));
+  });
+
+  it("returns already encoded slugs as-is", () => {
+    const encoded = encodeURIComponent("江東区-ジム");
+    expect(encodeOnce(encoded)).toBe(encoded);
+  });
+
+  it("encodes strings with spaces only once", () => {
+    const slug = "tokyo gym";
+    expect(encodeOnce(slug)).toBe("tokyo%20gym");
+  });
+
+  it("encodes strings with invalid escape sequences", () => {
+    const invalid = "%E0%A4%A";
+    expect(encodeOnce(invalid)).toBe(encodeURIComponent(invalid));
+  });
+});

--- a/frontend/src/lib/url.ts
+++ b/frontend/src/lib/url.ts
@@ -1,0 +1,17 @@
+export function encodeOnce(slug: string): string {
+  if (slug.length === 0) {
+    return slug;
+  }
+
+  try {
+    const decoded = decodeURIComponent(slug);
+    if (encodeURIComponent(decoded) === slug) {
+      return slug;
+    }
+  } catch {
+    // If decoding fails, fall back to encoding the original string.
+    return encodeURIComponent(slug);
+  }
+
+  return encodeURIComponent(slug);
+}

--- a/frontend/src/services/gyms.ts
+++ b/frontend/src/services/gyms.ts
@@ -1,4 +1,5 @@
 import { apiRequest } from "@/lib/apiClient";
+import { encodeOnce } from "@/lib/url";
 import {
   fetchGyms as fetchGymsApi,
   normalizeGymSummary,
@@ -256,7 +257,7 @@ export async function getGymBySlug(
   slug: string,
   options: { signal?: AbortSignal } = {},
 ): Promise<GymDetail> {
-  const response = await apiRequest<RawGymDetail>(`/gyms/${slug}`, {
+  const response = await apiRequest<RawGymDetail>(`/gyms/${encodeOnce(slug)}`, {
     method: "GET",
     signal: options.signal,
   });

--- a/frontend/src/services/reports.ts
+++ b/frontend/src/services/reports.ts
@@ -1,4 +1,5 @@
 import { apiRequest } from "@/lib/apiClient";
+import { encodeOnce } from "@/lib/url";
 
 export type ReportGymIssueReason = "hours" | "equipment" | "address" | "closed" | "other";
 
@@ -17,7 +18,7 @@ export const reportGymIssue = async (
   slug: string,
   payload: ReportGymIssuePayload,
 ): Promise<ReportGymIssueResponse | undefined> =>
-  apiRequest<ReportGymIssueResponse | undefined>(`/gyms/${encodeURIComponent(slug)}/report`, {
+  apiRequest<ReportGymIssueResponse | undefined>(`/gyms/${encodeOnce(slug)}/report`, {
     method: "POST",
     body: JSON.stringify(payload),
   });

--- a/migrations/versions/c5f2d68f2b31_add_response_meta_to_scraped_pages.py
+++ b/migrations/versions/c5f2d68f2b31_add_response_meta_to_scraped_pages.py
@@ -18,13 +18,11 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     op.execute(
-        "ALTER TABLE scraped_pages "
-        "ADD COLUMN IF NOT EXISTS response_meta JSONB",
+        "ALTER TABLE scraped_pages ADD COLUMN IF NOT EXISTS response_meta JSONB",
     )
 
 
 def downgrade() -> None:
     op.execute(
-        "ALTER TABLE scraped_pages "
-        "DROP COLUMN IF EXISTS response_meta",
+        "ALTER TABLE scraped_pages DROP COLUMN IF EXISTS response_meta",
     )

--- a/scripts/ingest/cli.py
+++ b/scripts/ingest/cli.py
@@ -64,7 +64,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--limit",
         type=int,
         default=DEFAULT_LIMIT,
-        help="Number of detail pages to fetch (1-50)",
+        help="Number of detail pages to fetch (1-30)",
     )
     fetch_http_parser.add_argument(
         "--min-delay",

--- a/scripts/ingest/normalize.py
+++ b/scripts/ingest/normalize.py
@@ -12,7 +12,7 @@ from app.models.equipment import Equipment
 from app.models.gym_candidate import GymCandidate
 from app.models.scraped_page import ScrapedPage
 
-from .sites import site_a
+from .sites import municipal_koto, site_a
 from .utils import get_or_create_source
 
 logger = logging.getLogger(__name__)
@@ -43,13 +43,21 @@ _SITE_A_CITY_MAP = {
     "千葉市": "chiba",
     "美浜区": "mihama",
 }
+_MUNICIPAL_KOTO_PREF_MAP = {
+    "東京都": "tokyo",
+}
+_MUNICIPAL_KOTO_CITY_MAP = {
+    "江東区": "koto",
+}
 _PREF_MAPS = {
     "dummy": _DUMMY_PREF_MAP,
     site_a.SITE_ID: _SITE_A_PREF_MAP,
+    municipal_koto.SITE_ID: _MUNICIPAL_KOTO_PREF_MAP,
 }
 _CITY_MAPS = {
     "dummy": _DUMMY_CITY_MAP,
     site_a.SITE_ID: _SITE_A_CITY_MAP,
+    municipal_koto.SITE_ID: _MUNICIPAL_KOTO_CITY_MAP,
 }
 
 

--- a/scripts/ingest/parse.py
+++ b/scripts/ingest/parse.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 import re
 import unicodedata
+from collections.abc import Iterable
 from itertools import cycle
-from typing import Any, Iterable
+from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy import select

--- a/scripts/ingest/sites/__init__.py
+++ b/scripts/ingest/sites/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from . import site_a
+from . import municipal_koto, site_a
 
-__all__ = ["site_a"]
+__all__ = ["site_a", "municipal_koto"]

--- a/scripts/ingest/sites/municipal_koto.py
+++ b/scripts/ingest/sites/municipal_koto.py
@@ -1,118 +1,98 @@
-"""Ingest helpers for the Koto municipal sports facility site."""
+"""Helpers for scraping Koto municipal sports facility pages."""
 
 from __future__ import annotations
 
 import unicodedata
-from collections.abc import Iterable, Iterator
-from dataclasses import dataclass
+from collections.abc import Iterable
 from typing import Final
-from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 
 SITE_ID: Final[str] = "municipal_koto"
-BASE_URL: Final[str] = "https://www.koto-hsc.or.jp"
 ALLOWED_HOSTS: Final[tuple[str, ...]] = ("www.koto-hsc.or.jp",)
+BASE_URL: Final[str] = "https://www.koto-hsc.or.jp"
 SUPPORTED_AREAS: Final[set[tuple[str, str]]] = {("tokyo", "koto")}
 
-_DETAIL_PATHS: dict[tuple[str, str], tuple[str, ...]] = {
-    ("tokyo", "koto"): (
-        "/facility/koto-sc/",  # 江東区スポーツ会館
-        "/facility/kameido-sc/",  # 亀戸スポーツセンター
-        "/facility/sunamachi-sc/",  # 砂町スポーツセンター
-    ),
-}
+# Known facility detail paths (江東区スポーツセンター群)
+_DETAIL_PATHS: Final[tuple[str, ...]] = (
+    "/sports_center2/",  # 深川北
+    "/sports_center3/",  # 亀戸
+    "/sports_center4/",  # 有明
+    "/sports_center5/",  # 東砂
+    "/sports_center2/introduction/",
+    "/sports_center3/introduction/",
+    "/sports_center4/introduction/",
+    "/sports_center5/introduction/",
+)
 
 
-def _normalize_area(pref: str, city: str) -> tuple[str, str]:
-    pref_slug = pref.strip().lower()
-    city_slug = city.strip().lower()
-    key = (pref_slug, city_slug)
-    if key not in SUPPORTED_AREAS:
-        msg = f"Unsupported area for municipal_koto: pref={pref}, city={city}"
-        raise ValueError(msg)
-    return key
+def iter_listing_urls(pref: str, city: str, *, limit: int | None = None) -> Iterable[str]:
+    """Return a slice of known detail paths for the supported area."""
+
+    _ = pref, city  # unused but keeps signature consistent
+    paths = list(_DETAIL_PATHS)
+    if limit is not None:
+        clamped = max(0, min(limit, len(paths)))
+        paths = paths[:clamped]
+    return paths
 
 
-def _normalize_text(value: str | None) -> str:
+def _norm(value: str | None) -> str:
     if not value:
         return ""
-    normalized = unicodedata.normalize("NFKC", value)
-    return normalized.strip()
+    return unicodedata.normalize("NFKC", value).strip()
 
 
-def iter_listing_urls(pref: str, city: str) -> Iterator[str]:
-    """Yield absolute URLs for detail pages within the supported area."""
-
-    key = _normalize_area(pref, city)
-    for path in _DETAIL_PATHS.get(key, ()):  # pragma: no cover - defensive
-        yield urljoin(BASE_URL, path)
-
-
-@dataclass(slots=True)
-class MunicipalKotoDetail:
-    """Structured data parsed from a municipal facility detail page."""
-
-    name: str
-    address: str
-    equipments_raw: list[str]
-
-
-def _extract_name(soup: BeautifulSoup) -> str:
-    for selector in ("h1", ".page-title", ".facility-title"):
-        node = soup.select_one(selector)
-        if not node:
-            continue
-        text = node.get_text(strip=True)
-        if text:
-            return _normalize_text(text)
-    return ""
-
-
-def _extract_address(soup: BeautifulSoup) -> str:
-    if node := soup.select_one("address"):
-        text = node.get_text(strip=True)
-        if text:
-            return _normalize_text(text)
-    for selector in (".facility-address", ".detail-address", "p.address"):
-        node = soup.select_one(selector)
-        if not node:
-            continue
-        text = node.get_text(strip=True)
-        if text:
-            return _normalize_text(text)
-    return ""
-
-
-def _extract_equipments(soup: BeautifulSoup) -> list[str]:
-    equipments: list[str] = []
-    for selector in ("ul.equipments li", "ul.facility-equipments li", "ul#equipments li"):
-        for node in soup.select(selector):
-            text = node.get_text(strip=True)
-            normalized = _normalize_text(text)
-            if normalized:
-                equipments.append(normalized)
-        if equipments:
-            break
-    return equipments
-
-
-def parse_detail(html: str) -> MunicipalKotoDetail:
-    """Parse a municipal facility detail page and return structured data."""
+def parse_detail(html: str) -> dict[str, str | list[str] | None]:
+    """Extract name, address, and equipment strings from a detail HTML page."""
 
     soup = BeautifulSoup(html or "", "html.parser")
-    name = _extract_name(soup)
-    address = _extract_address(soup)
-    equipments = _extract_equipments(soup)
-    return MunicipalKotoDetail(name=name, address=address, equipments_raw=equipments)
 
-
-def normalize_equipments(equipments: Iterable[str]) -> list[str]:
-    """Normalize raw equipment strings (NFKC conversion)."""
-
-    normalized: list[str] = []
-    for equipment in equipments:
-        text = _normalize_text(equipment)
+    name = ""
+    if h1 := soup.find("h1"):
+        text = h1.get_text(" ", strip=True)
         if text:
-            normalized.append(text)
-    return normalized
+            name = _norm(text)
+    if not name and soup.title:
+        title_text = soup.title.get_text(" ", strip=True)
+        name = _norm(title_text)
+
+    address = ""
+    if address_tag := soup.find("address"):
+        text = address_tag.get_text(" ", strip=True)
+        address = _norm(text)
+    if not address:
+        text = soup.get_text("\n", strip=True)
+        for line in text.splitlines():
+            if "〒" in line or "東京都" in line:
+                address = _norm(line)
+                if address:
+                    break
+
+    equipments_raw: list[str] = []
+    keywords = ("トレーニング", "マシン", "ダンベル", "スミス", "ベンチ", "ラット")
+    for li in soup.select("ul li"):
+        value = _norm(li.get_text(" ", strip=True))
+        if value and any(keyword in value for keyword in keywords):
+            equipments_raw.append(value)
+    if not equipments_raw:
+        for paragraph in soup.select("p"):
+            value = _norm(paragraph.get_text(" ", strip=True))
+            if value and any(keyword in value for keyword in keywords):
+                equipments_raw.append(value)
+
+    return {
+        "name": name,
+        "address": address or None,
+        "equipments_raw": equipments_raw,
+    }
+
+
+__all__ = [
+    "SITE_ID",
+    "ALLOWED_HOSTS",
+    "BASE_URL",
+    "SUPPORTED_AREAS",
+    "iter_listing_urls",
+    "parse_detail",
+]

--- a/scripts/ingest/sites/municipal_koto.py
+++ b/scripts/ingest/sites/municipal_koto.py
@@ -40,7 +40,7 @@ def iter_listing_urls(pref: str, city: str, *, limit: int | None = None) -> Iter
 def _norm(value: str | None) -> str:
     if not value:
         return ""
-    return unicodedata.normalize("NFKC", value).strip()
+    return unicodedata.normalize("NFKC", value).replace("\x00", "").strip()
 
 
 def parse_detail(html: str) -> dict[str, str | list[str] | None]:
@@ -80,6 +80,9 @@ def parse_detail(html: str) -> dict[str, str | list[str] | None]:
             value = _norm(paragraph.get_text(" ", strip=True))
             if value and any(keyword in value for keyword in keywords):
                 equipments_raw.append(value)
+
+    if name:
+        name = name.replace("施設案内 | ", "").replace("| 江東区", "").strip()
 
     return {
         "name": name,

--- a/scripts/ingest/sites/municipal_koto.py
+++ b/scripts/ingest/sites/municipal_koto.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import unicodedata
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from typing import Final
 from urllib.parse import urljoin
-import unicodedata
 
 from bs4 import BeautifulSoup
 

--- a/scripts/ingest/sites/municipal_koto.py
+++ b/scripts/ingest/sites/municipal_koto.py
@@ -1,0 +1,118 @@
+"""Ingest helpers for the Koto municipal sports facility site."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from typing import Final
+from urllib.parse import urljoin
+import unicodedata
+
+from bs4 import BeautifulSoup
+
+SITE_ID: Final[str] = "municipal_koto"
+BASE_URL: Final[str] = "https://www.koto-hsc.or.jp"
+ALLOWED_HOSTS: Final[tuple[str, ...]] = ("www.koto-hsc.or.jp",)
+SUPPORTED_AREAS: Final[set[tuple[str, str]]] = {("tokyo", "koto")}
+
+_DETAIL_PATHS: dict[tuple[str, str], tuple[str, ...]] = {
+    ("tokyo", "koto"): (
+        "/facility/koto-sc/",  # 江東区スポーツ会館
+        "/facility/kameido-sc/",  # 亀戸スポーツセンター
+        "/facility/sunamachi-sc/",  # 砂町スポーツセンター
+    ),
+}
+
+
+def _normalize_area(pref: str, city: str) -> tuple[str, str]:
+    pref_slug = pref.strip().lower()
+    city_slug = city.strip().lower()
+    key = (pref_slug, city_slug)
+    if key not in SUPPORTED_AREAS:
+        msg = f"Unsupported area for municipal_koto: pref={pref}, city={city}"
+        raise ValueError(msg)
+    return key
+
+
+def _normalize_text(value: str | None) -> str:
+    if not value:
+        return ""
+    normalized = unicodedata.normalize("NFKC", value)
+    return normalized.strip()
+
+
+def iter_listing_urls(pref: str, city: str) -> Iterator[str]:
+    """Yield absolute URLs for detail pages within the supported area."""
+
+    key = _normalize_area(pref, city)
+    for path in _DETAIL_PATHS.get(key, ()):  # pragma: no cover - defensive
+        yield urljoin(BASE_URL, path)
+
+
+@dataclass(slots=True)
+class MunicipalKotoDetail:
+    """Structured data parsed from a municipal facility detail page."""
+
+    name: str
+    address: str
+    equipments_raw: list[str]
+
+
+def _extract_name(soup: BeautifulSoup) -> str:
+    for selector in ("h1", ".page-title", ".facility-title"):
+        node = soup.select_one(selector)
+        if not node:
+            continue
+        text = node.get_text(strip=True)
+        if text:
+            return _normalize_text(text)
+    return ""
+
+
+def _extract_address(soup: BeautifulSoup) -> str:
+    if node := soup.select_one("address"):
+        text = node.get_text(strip=True)
+        if text:
+            return _normalize_text(text)
+    for selector in (".facility-address", ".detail-address", "p.address"):
+        node = soup.select_one(selector)
+        if not node:
+            continue
+        text = node.get_text(strip=True)
+        if text:
+            return _normalize_text(text)
+    return ""
+
+
+def _extract_equipments(soup: BeautifulSoup) -> list[str]:
+    equipments: list[str] = []
+    for selector in ("ul.equipments li", "ul.facility-equipments li", "ul#equipments li"):
+        for node in soup.select(selector):
+            text = node.get_text(strip=True)
+            normalized = _normalize_text(text)
+            if normalized:
+                equipments.append(normalized)
+        if equipments:
+            break
+    return equipments
+
+
+def parse_detail(html: str) -> MunicipalKotoDetail:
+    """Parse a municipal facility detail page and return structured data."""
+
+    soup = BeautifulSoup(html or "", "html.parser")
+    name = _extract_name(soup)
+    address = _extract_address(soup)
+    equipments = _extract_equipments(soup)
+    return MunicipalKotoDetail(name=name, address=address, equipments_raw=equipments)
+
+
+def normalize_equipments(equipments: Iterable[str]) -> list[str]:
+    """Normalize raw equipment strings (NFKC conversion)."""
+
+    normalized: list[str] = []
+    for equipment in equipments:
+        text = _normalize_text(equipment)
+        if text:
+            normalized.append(text)
+    return normalized

--- a/scripts/ingest/sites/site_a.py
+++ b/scripts/ingest/sites/site_a.py
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 
 SITE_ID = "site_a"
 BASE_URL = "https://site-a.example.com"
+ALLOWED_HOSTS = ("site-a.example.com",)
 SUPPORTED_HTTP_AREAS = {("tokyo", "koto"), ("chiba", "funabashi")}
 _LISTING_PAGE_RANGE = range(1, 4)
 

--- a/tests/test_ingest_municipal_koto_normalize.py
+++ b/tests/test_ingest_municipal_koto_normalize.py
@@ -5,13 +5,16 @@ from scripts.ingest.sites import municipal_koto as site
 
 
 def test_name_cleanup_and_norm() -> None:
-    name = "施設案内 | 亀戸スポーツセンター\x00| 江東区"
+    name = "施設案内｜亀戸スポーツセンター\x00｜江東区"
     html = f"<html><head><title>{name}</title></head><body><h1>{name}</h1></body></html>"
     data = site.parse_detail(html)
     assert data["name"] == "亀戸スポーツセンター"
 
 
 def test_pref_city_assign() -> None:
-    assert _assign_pref_city_for_municipal_koto("東京都江東区有明2-3-5") == ("tokyo", "koto")
-    assert _assign_pref_city_for_municipal_koto("江東区豊洲1-2-3") == ("tokyo", "koto")
-    assert _assign_pref_city_for_municipal_koto(None) == (None, None)
+    assert _assign_pref_city_for_municipal_koto("東京都江東区有明2-3-5", None) == (
+        "tokyo",
+        "koto",
+    )
+    assert _assign_pref_city_for_municipal_koto("", "深川スポーツセンター") == ("tokyo", "koto")
+    assert _assign_pref_city_for_municipal_koto(None, None) == (None, None)

--- a/tests/test_ingest_municipal_koto_normalize.py
+++ b/tests/test_ingest_municipal_koto_normalize.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from scripts.ingest.normalize import _assign_pref_city_for_municipal_koto
+from scripts.ingest.sites import municipal_koto as site
+
+
+def test_name_cleanup_and_norm() -> None:
+    name = "施設案内 | 亀戸スポーツセンター\x00| 江東区"
+    html = f"<html><head><title>{name}</title></head><body><h1>{name}</h1></body></html>"
+    data = site.parse_detail(html)
+    assert data["name"] == "亀戸スポーツセンター"
+
+
+def test_pref_city_assign() -> None:
+    assert _assign_pref_city_for_municipal_koto("東京都江東区有明2-3-5") == ("tokyo", "koto")
+    assert _assign_pref_city_for_municipal_koto("江東区豊洲1-2-3") == ("tokyo", "koto")
+    assert _assign_pref_city_for_municipal_koto(None) == (None, None)

--- a/tests/test_ingest_municipal_koto_parse.py
+++ b/tests/test_ingest_municipal_koto_parse.py
@@ -1,0 +1,50 @@
+from scripts.ingest.parse import map_municipal_koto_equipments
+from scripts.ingest.sites import municipal_koto
+
+
+def test_parse_detail_extracts_expected_fields() -> None:
+    html = """
+    <html>
+      <body>
+        <div class="facility-detail">
+          <h1>亀戸スポーツセンター</h1>
+          <address>東京都江東区亀戸１－２－３</address>
+          <ul class="equipments">
+            <li>スミスマシン</li>
+            <li> ベンチプレス </li>
+            <li>ラットプル</li>
+          </ul>
+        </div>
+      </body>
+    </html>
+    """
+
+    detail = municipal_koto.parse_detail(html)
+
+    assert detail.name == "亀戸スポーツセンター"
+    assert detail.address == "東京都江東区亀戸1-2-3"
+    assert detail.equipments_raw == ["スミスマシン", "ベンチプレス", "ラットプル"]
+
+
+def test_map_municipal_koto_equipments_matches_known_slugs() -> None:
+    equipments = [
+        "スミス",
+        "ベンチプレス台",
+        "ダンベルセット",
+        "ラットプルダウン",
+        "レッグプレスマシン",
+        "フィットネスバイク",
+        "未知設備",
+        "スミス",  # duplicate should be ignored
+    ]
+
+    mapped = map_municipal_koto_equipments(equipments)
+
+    assert mapped == [
+        "smith-machine",
+        "bench-press",
+        "dumbbell",
+        "lat-pulldown",
+        "leg-press",
+        "upright-bike",
+    ]


### PR DESCRIPTION
## 目的
- 江東区の公共スポーツ施設ページから候補データを取得できるようにする

## 変更点
- municipal_koto ソース用のサイト定義とテストを追加
- fetch-http/parse/normalize パイプラインを municipal_koto に対応させ、安全弁や装備マッピングを実装
- Makefile・CLI のターゲットを municipal_koto 用に拡張

## 確認手順
- [ ] 江東区サイトで fetch-http → parse → normalize の順に実行して候補が作成されること

## CI
- [ ] GitHub Actions が全て成功

------
https://chatgpt.com/codex/tasks/task_e_68dd108d1990832a90132ef7686afcea