### PR TITLE
feat: Admin UI で候補承認フローを実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ gym-equipment-directory/
 - 承認: 公開テーブルへの upsert（`dry_run` 指定でプレビューのみ実行も可能）
 - 却下: 理由付きで候補を非承認扱いに変更
 
+### Admin UI
+
+- `.env` に `ADMIN_UI_TOKEN` を設定すると、Next.js フロントの `/admin` 配下を同じトークンで保護します。
+- ブラウザで `http://localhost:3000/admin/login` にアクセス → トークンを入力すると Cookie に保存され、`/admin/candidates` へ遷移します。
+- 一覧から候補を選択すると詳細画面に移動し、以下を UI 上で実行できます。
+  - フィールドの編集 (`PATCH /admin/candidates/{id}`)
+  - Dry-run 承認（差分プレビュー表示）
+  - 本承認（成功時に `/gyms/{slug}` へのリンク付きトーストを表示）
+  - 却下（理由必須）
+- 承認 API のレート制限(HTTP 429)には UI 側で自動リトライ（Retry-After 対応）を実装しています。
+
 ## 🏋️ Ingest パイプラインの使い方
 
 `site_a` のスクレイピングフローをローカルで試す場合は、以下のコマンドを順番に実行します。

--- a/frontend/app/admin/candidates/[id]/page.tsx
+++ b/frontend/app/admin/candidates/[id]/page.tsx
@@ -1,0 +1,560 @@
+"use client";
+
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+
+import { toast } from "@/components/ui/use-toast";
+import {
+  AdminApiError,
+  AdminCandidateDetail,
+  AdminCandidateItem,
+  ApprovePreviewResponse,
+  ApproveResultResponse,
+  ApproveSummary,
+  ApproveOverride,
+  getCandidate,
+  approveCandidate,
+  patchCandidate,
+  rejectCandidate,
+} from "@/lib/adminApi";
+
+const formatDateTime = (value: string | undefined | null) => {
+  if (!value) {
+    return "-";
+  }
+  try {
+    return new Date(value).toLocaleString("ja-JP");
+  } catch (error) {
+    return value;
+  }
+};
+
+type FormState = {
+  name_raw: string;
+  address_raw: string;
+  pref_slug: string;
+  city_slug: string;
+  latitude: string;
+  longitude: string;
+  parsed_json: string;
+};
+
+const toFormState = (candidate: AdminCandidateDetail): FormState => ({
+  name_raw: candidate.name_raw ?? "",
+  address_raw: candidate.address_raw ?? "",
+  pref_slug: candidate.pref_slug ?? "",
+  city_slug: candidate.city_slug ?? "",
+  latitude:
+    candidate.latitude !== undefined && candidate.latitude !== null
+      ? String(candidate.latitude)
+      : "",
+  longitude:
+    candidate.longitude !== undefined && candidate.longitude !== null
+      ? String(candidate.longitude)
+      : "",
+  parsed_json: candidate.parsed_json ? JSON.stringify(candidate.parsed_json, null, 2) : "",
+});
+
+const parseJsonInput = (input: string): Record<string, unknown> | null => {
+  if (!input.trim()) {
+    return null;
+  }
+  return JSON.parse(input);
+};
+
+type PreviewState = {
+  summary: ApproveSummary | null;
+  open: boolean;
+};
+
+const INITIAL_PREVIEW_STATE: PreviewState = {
+  summary: null,
+  open: false,
+};
+
+type CandidateActionState = "idle" | "saving" | "approving" | "rejecting";
+
+export default function AdminCandidateDetailPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const candidateId = Number(params?.id);
+  const [candidate, setCandidate] = useState<AdminCandidateDetail | null>(null);
+  const [formState, setFormState] = useState<FormState | null>(null);
+  const [preview, setPreview] = useState<PreviewState>(INITIAL_PREVIEW_STATE);
+  const [actionState, setActionState] = useState<CandidateActionState>("idle");
+  const [rejectReason, setRejectReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const loadCandidate = useCallback(async () => {
+    if (Number.isNaN(candidateId)) {
+      setError("候補IDが不正です");
+      return;
+    }
+    try {
+      const detail = await getCandidate(candidateId);
+      setCandidate(detail);
+      setFormState(toFormState(detail));
+      setError(null);
+    } catch (err) {
+      if (err instanceof AdminApiError) {
+        setError(err.message);
+      } else {
+        setError("候補の取得に失敗しました");
+      }
+    }
+  }, [candidateId]);
+
+  useEffect(() => {
+    void loadCandidate();
+  }, [loadCandidate]);
+
+  const updateCandidateState = (item: AdminCandidateItem) => {
+    setCandidate(prev => {
+      if (!prev) {
+        return null;
+      }
+      const merged: AdminCandidateDetail = {
+        ...prev,
+        ...item,
+      };
+      setFormState(toFormState(merged));
+      return merged;
+    });
+  };
+
+  const handleInputChange = <T extends keyof FormState>(key: T, value: FormState[T]) => {
+    setFormState(prev => (prev ? { ...prev, [key]: value } : prev));
+  };
+
+  const handleSave = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!formState || !candidate) {
+      return;
+    }
+    let parsed: Record<string, unknown> | null = null;
+    try {
+      parsed = parseJsonInput(formState.parsed_json);
+    } catch (err) {
+      toast({
+        title: "JSONの解析に失敗しました",
+        description: err instanceof Error ? err.message : "不正なJSONです",
+        variant: "destructive",
+      });
+      return;
+    }
+    setActionState("saving");
+    try {
+      const payload = {
+        name_raw: formState.name_raw || candidate.name_raw,
+        address_raw: formState.address_raw || null,
+        pref_slug: formState.pref_slug || null,
+        city_slug: formState.city_slug || null,
+        latitude: formState.latitude ? Number(formState.latitude) : null,
+        longitude: formState.longitude ? Number(formState.longitude) : null,
+        parsed_json: parsed,
+      };
+      const updated = await patchCandidate(candidate.id, payload);
+      updateCandidateState(updated);
+      toast({ title: "候補を保存しました" });
+    } catch (err) {
+      if (err instanceof AdminApiError && err.status === 400) {
+        const detail = typeof err.detail === "string" ? err.detail : err.message;
+        toast({
+          title: "保存に失敗しました",
+          description: detail,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "保存に失敗しました",
+          description: err instanceof Error ? err.message : "不明なエラーです",
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setActionState("idle");
+    }
+  };
+
+  const handleDryRun = async () => {
+    if (!candidate) {
+      return;
+    }
+    setActionState("approving");
+    try {
+      const response = (await approveCandidate(candidate.id, {
+        dry_run: true,
+      })) as ApprovePreviewResponse;
+      setPreview({ summary: response.preview, open: true });
+    } catch (err) {
+      if (err instanceof AdminApiError) {
+        toast({
+          title: "Dry-run に失敗しました",
+          description: typeof err.detail === "string" ? err.detail : err.message,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "Dry-run に失敗しました",
+          description: err instanceof Error ? err.message : "不明なエラーです",
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setActionState("idle");
+    }
+  };
+
+  const performApproval = async (override?: ApproveOverride | null) => {
+    if (!candidate) {
+      return;
+    }
+    setActionState("approving");
+    try {
+      const response = (await approveCandidate(candidate.id, {
+        dry_run: false,
+        override: override ?? undefined,
+      })) as ApproveResultResponse;
+      const { result } = response;
+      const slugLink = `/gyms/${result.gym.slug}`;
+      toast({
+        title: "承認しました",
+        description: (
+          <a className="text-blue-600 underline" href={slugLink} target="_blank" rel="noreferrer">
+            {slugLink}
+          </a>
+        ),
+      });
+      setPreview({ summary: result, open: true });
+      void loadCandidate();
+    } catch (err) {
+      if (err instanceof AdminApiError) {
+        if (err.status === 409) {
+          const overrideName = window.prompt(
+            "slug が重複しています。上書きする名称を入力してください",
+          );
+          if (overrideName) {
+            await performApproval({ name: overrideName });
+          }
+          return;
+        }
+        toast({
+          title: "承認に失敗しました",
+          description: typeof err.detail === "string" ? err.detail : err.message,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "承認に失敗しました",
+          description: err instanceof Error ? err.message : "不明なエラーです",
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setActionState("idle");
+    }
+  };
+
+  const handleReject = async () => {
+    if (!candidate || !rejectReason.trim()) {
+      toast({
+        title: "却下理由を入力してください",
+        variant: "destructive",
+      });
+      return;
+    }
+    if (!window.confirm("この候補を却下しますか？")) {
+      return;
+    }
+    setActionState("rejecting");
+    try {
+      const updated = await rejectCandidate(candidate.id, { reason: rejectReason.trim() });
+      updateCandidateState(updated);
+      toast({ title: "候補を却下しました" });
+    } catch (err) {
+      if (err instanceof AdminApiError) {
+        toast({
+          title: "却下に失敗しました",
+          description: typeof err.detail === "string" ? err.detail : err.message,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "却下に失敗しました",
+          description: err instanceof Error ? err.message : "不明なエラーです",
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setActionState("idle");
+    }
+  };
+
+  const closePreview = useCallback(() => {
+    setPreview({ summary: null, open: false });
+  }, []);
+
+  const isLoading = !candidate && !error;
+
+  const renderPreview = useMemo(() => {
+    if (!preview.open || !preview.summary) {
+      return null;
+    }
+    const { gym, equipments } = preview.summary;
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+        <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-md bg-white p-6 shadow-lg">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold">承認結果プレビュー</h2>
+            <button type="button" className="text-sm text-gray-500" onClick={closePreview}>
+              閉じる
+            </button>
+          </div>
+          <section className="mb-4 space-y-2">
+            <h3 className="text-sm font-semibold text-gray-700">ジム情報</h3>
+            <div className="rounded border border-gray-200 p-3 text-sm">
+              <p>
+                <span className="font-medium">名称:</span> {gym.name}
+              </p>
+              <p>
+                <span className="font-medium">Slug:</span> <code>{gym.slug}</code>
+              </p>
+              <p>
+                <span className="font-medium">Canonical ID:</span> {gym.canonical_id}
+              </p>
+              <p>
+                <span className="font-medium">住所:</span> {gym.address ?? "-"}
+              </p>
+              <p>
+                <span className="font-medium">位置:</span> {gym.pref_slug ?? "-"} /{" "}
+                {gym.city_slug ?? "-"} ({gym.latitude ?? "-"}, {gym.longitude ?? "-"})
+              </p>
+            </div>
+          </section>
+          <section className="space-y-2">
+            <h3 className="text-sm font-semibold text-gray-700">設備サマリ</h3>
+            <div className="rounded border border-gray-200 p-3 text-sm">
+              <p>
+                追加: {equipments.inserted} / 更新: {equipments.updated} / 合計: {equipments.total}
+              </p>
+            </div>
+          </section>
+        </div>
+      </div>
+    );
+  }, [preview, closePreview]);
+
+  if (error) {
+    return (
+      <div className="rounded border border-red-200 bg-red-50 p-6">
+        <p className="text-sm text-red-700">{error}</p>
+        <button
+          type="button"
+          className="mt-3 rounded border border-red-400 px-3 py-1 text-xs"
+          onClick={() => void loadCandidate()}
+        >
+          再読み込み
+        </button>
+      </div>
+    );
+  }
+
+  if (isLoading || !candidate || !formState) {
+    return <p className="text-sm text-gray-600">読み込み中...</p>;
+  }
+
+  return (
+    <Fragment>
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">候補詳細 #{candidate.id}</h1>
+          <p className="text-sm text-gray-500">
+            ステータス: <span className="font-medium text-gray-700">{candidate.status}</span>
+          </p>
+        </div>
+        <button type="button" className="text-sm text-gray-500" onClick={() => router.back()}>
+          一覧へ戻る
+        </button>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <form
+          onSubmit={handleSave}
+          className="flex flex-col gap-4 rounded border border-gray-200 p-4 shadow-sm"
+        >
+          <h2 className="text-lg font-semibold">編集</h2>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium">名称</span>
+            <input
+              className="rounded border border-gray-300 px-3 py-2"
+              value={formState.name_raw}
+              onChange={event => handleInputChange("name_raw", event.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium">住所</span>
+            <textarea
+              className="h-20 rounded border border-gray-300 px-3 py-2"
+              value={formState.address_raw}
+              onChange={event => handleInputChange("address_raw", event.target.value)}
+            />
+          </label>
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="font-medium">都道府県スラッグ</span>
+              <input
+                className="rounded border border-gray-300 px-3 py-2"
+                value={formState.pref_slug}
+                onChange={event => handleInputChange("pref_slug", event.target.value)}
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="font-medium">市区町村スラッグ</span>
+              <input
+                className="rounded border border-gray-300 px-3 py-2"
+                value={formState.city_slug}
+                onChange={event => handleInputChange("city_slug", event.target.value)}
+              />
+            </label>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="font-medium">緯度</span>
+              <input
+                className="rounded border border-gray-300 px-3 py-2"
+                value={formState.latitude}
+                onChange={event => handleInputChange("latitude", event.target.value)}
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="font-medium">経度</span>
+              <input
+                className="rounded border border-gray-300 px-3 py-2"
+                value={formState.longitude}
+                onChange={event => handleInputChange("longitude", event.target.value)}
+              />
+            </label>
+          </div>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="font-medium">解析済みJSON</span>
+            <textarea
+              className="h-52 rounded border border-gray-300 px-3 py-2 font-mono text-xs"
+              value={formState.parsed_json}
+              onChange={event => handleInputChange("parsed_json", event.target.value)}
+            />
+          </label>
+          <button
+            type="submit"
+            className="mt-2 rounded bg-black px-4 py-2 text-sm font-semibold text-white transition hover:bg-gray-800"
+            disabled={actionState === "saving"}
+          >
+            {actionState === "saving" ? "保存中..." : "保存"}
+          </button>
+        </form>
+        <div className="flex flex-col gap-4">
+          <section className="rounded border border-gray-200 p-4 shadow-sm">
+            <h2 className="text-lg font-semibold">スクレイプ情報</h2>
+            <dl className="mt-3 space-y-2 text-sm">
+              <div className="flex justify-between">
+                <dt className="font-medium">URL</dt>
+                <dd>
+                  <a
+                    className="text-blue-600 underline"
+                    href={candidate.scraped_page.url}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {candidate.scraped_page.url}
+                  </a>
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="font-medium">Fetched</dt>
+                <dd>{formatDateTime(candidate.scraped_page.fetched_at)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="font-medium">HTTP Status</dt>
+                <dd>{candidate.scraped_page.http_status ?? "-"}</dd>
+              </div>
+            </dl>
+          </section>
+          <section className="rounded border border-gray-200 p-4 shadow-sm">
+            <h2 className="text-lg font-semibold">類似ジム</h2>
+            <ul className="mt-3 space-y-2 text-sm">
+              {(candidate.similar ?? []).length === 0 ? (
+                <li className="text-gray-500">類似ジムはありません</li>
+              ) : (
+                candidate.similar?.map(similar => (
+                  <li key={similar.gym_id}>
+                    <a
+                      className="text-blue-600 underline"
+                      href={`/gyms/${similar.gym_slug}`}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {similar.gym_name} ({similar.gym_slug})
+                    </a>
+                  </li>
+                ))
+              )}
+            </ul>
+          </section>
+          <section className="rounded border border-gray-200 p-4 shadow-sm">
+            <h2 className="text-lg font-semibold">メタ情報</h2>
+            <dl className="mt-3 space-y-2 text-sm">
+              <div className="flex justify-between">
+                <dt className="font-medium">Fetched</dt>
+                <dd>{formatDateTime(candidate.fetched_at)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="font-medium">Updated</dt>
+                <dd>{formatDateTime(candidate.updated_at)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="font-medium">Source</dt>
+                <dd>{candidate.source?.title ?? "-"}</dd>
+              </div>
+            </dl>
+          </section>
+        </div>
+      </div>
+      <section className="mt-6 rounded border border-gray-200 p-4 shadow-sm">
+        <h2 className="text-lg font-semibold">アクション</h2>
+        <div className="mt-3 flex flex-wrap gap-3">
+          <button
+            type="button"
+            className="rounded border border-gray-300 px-4 py-2 text-sm"
+            onClick={handleDryRun}
+            disabled={actionState !== "idle"}
+          >
+            {actionState === "approving" ? "処理中..." : "Dry-run 承認"}
+          </button>
+          <button
+            type="button"
+            className="rounded bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700"
+            onClick={() => void performApproval()}
+            disabled={actionState !== "idle"}
+          >
+            本承認
+          </button>
+          <div className="flex items-center gap-2">
+            <textarea
+              className="h-16 w-64 rounded border border-gray-300 px-3 py-2 text-sm"
+              placeholder="却下理由"
+              value={rejectReason}
+              onChange={event => setRejectReason(event.target.value)}
+            />
+            <button
+              type="button"
+              className="rounded bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700"
+              onClick={handleReject}
+              disabled={actionState !== "idle"}
+            >
+              却下
+            </button>
+          </div>
+        </div>
+      </section>
+      {renderPreview}
+    </Fragment>
+  );
+}

--- a/frontend/app/admin/candidates/page.tsx
+++ b/frontend/app/admin/candidates/page.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type { AdminCandidateItem, AdminCandidateListParams } from "@/lib/adminApi";
+import { AdminApiError, listCandidates } from "@/lib/adminApi";
+import { toast } from "@/components/ui/use-toast";
+
+const DEFAULT_FILTERS: AdminCandidateListParams = {
+  status: "",
+  source: "",
+  q: "",
+  pref: "",
+  city: "",
+};
+
+type Filters = AdminCandidateListParams & { q: string };
+
+const formatDateTime = (value: string | null | undefined) => {
+  if (!value) {
+    return "-";
+  }
+  try {
+    return new Date(value).toLocaleString("ja-JP");
+  } catch (error) {
+    return value;
+  }
+};
+
+export default function AdminCandidatesPage() {
+  const router = useRouter();
+  const [filters, setFilters] = useState<Filters>({ ...DEFAULT_FILTERS });
+  const [items, setItems] = useState<AdminCandidateItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const buildParams = useCallback(
+    (cursor?: string | null): AdminCandidateListParams => ({
+      status: filters.status?.trim() || undefined,
+      source: filters.source?.trim() || undefined,
+      q: filters.q?.trim() || undefined,
+      pref: filters.pref?.trim() || undefined,
+      city: filters.city?.trim() || undefined,
+      cursor: cursor || undefined,
+    }),
+    [filters],
+  );
+
+  const fetchCandidates = useCallback(
+    async (cursor?: string | null) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await listCandidates(buildParams(cursor));
+        setItems(response.items);
+        setNextCursor(response.next_cursor ?? null);
+      } catch (err) {
+        if (err instanceof AdminApiError) {
+          setError(err.message);
+        } else {
+          setError("ネットワークエラーが発生しました");
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [buildParams],
+  );
+
+  useEffect(() => {
+    void fetchCandidates();
+  }, [fetchCandidates]);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      void fetchCandidates();
+    },
+    [fetchCandidates],
+  );
+
+  const handleNext = () => {
+    if (!nextCursor) {
+      return;
+    }
+    void fetchCandidates(nextCursor);
+  };
+
+  const handleRowClick = (candidateId: number) => {
+    router.push(`/admin/candidates/${candidateId}`);
+  };
+
+  const filterControls = useMemo(
+    () => (
+      <form
+        onSubmit={handleSubmit}
+        className="mb-6 grid gap-4 rounded-md border border-gray-200 p-4 shadow-sm md:grid-cols-5"
+      >
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-gray-700" htmlFor="status">
+            Status
+          </label>
+          <select
+            id="status"
+            className="rounded border border-gray-300 px-3 py-2"
+            value={filters.status ?? ""}
+            onChange={event => setFilters(prev => ({ ...prev, status: event.target.value }))}
+          >
+            <option value="">全て</option>
+            <option value="new">new</option>
+            <option value="reviewing">reviewing</option>
+            <option value="approved">approved</option>
+            <option value="rejected">rejected</option>
+          </select>
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-gray-700" htmlFor="source">
+            Source
+          </label>
+          <input
+            id="source"
+            className="rounded border border-gray-300 px-3 py-2"
+            value={filters.source ?? ""}
+            onChange={event => setFilters(prev => ({ ...prev, source: event.target.value }))}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-gray-700" htmlFor="q">
+            キーワード
+          </label>
+          <input
+            id="q"
+            className="rounded border border-gray-300 px-3 py-2"
+            value={filters.q ?? ""}
+            onChange={event => setFilters(prev => ({ ...prev, q: event.target.value }))}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-gray-700" htmlFor="pref">
+            都道府県スラッグ
+          </label>
+          <input
+            id="pref"
+            className="rounded border border-gray-300 px-3 py-2"
+            value={filters.pref ?? ""}
+            onChange={event => setFilters(prev => ({ ...prev, pref: event.target.value }))}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-gray-700" htmlFor="city">
+            市区町村スラッグ
+          </label>
+          <input
+            id="city"
+            className="rounded border border-gray-300 px-3 py-2"
+            value={filters.city ?? ""}
+            onChange={event => setFilters(prev => ({ ...prev, city: event.target.value }))}
+          />
+        </div>
+        <div className="md:col-span-5">
+          <button
+            type="submit"
+            className="rounded bg-black px-4 py-2 text-sm font-semibold text-white transition hover:bg-gray-800"
+            disabled={loading}
+          >
+            {loading ? "検索中..." : "フィルター適用"}
+          </button>
+        </div>
+      </form>
+    ),
+    [filters.city, filters.pref, filters.q, filters.source, filters.status, loading, handleSubmit],
+  );
+
+  useEffect(() => {
+    if (error) {
+      toast({
+        title: "候補の取得に失敗しました",
+        description: error,
+        variant: "destructive",
+      });
+    }
+  }, [error]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-2xl font-semibold">Gym Candidates</h1>
+      {filterControls}
+      {loading ? (
+        <p className="text-sm text-gray-600">読み込み中...</p>
+      ) : error ? (
+        <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          <p>{error}</p>
+          <button
+            type="button"
+            className="mt-2 rounded border border-red-400 px-3 py-1 text-xs"
+            onClick={() => fetchCandidates()}
+          >
+            再試行
+          </button>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2 text-left font-semibold text-gray-600">ID</th>
+                <th className="px-3 py-2 text-left font-semibold text-gray-600">Status</th>
+                <th className="px-3 py-2 text-left font-semibold text-gray-600">Name</th>
+                <th className="px-3 py-2 text-left font-semibold text-gray-600">Source</th>
+                <th className="px-3 py-2 text-left font-semibold text-gray-600">Fetched</th>
+                <th className="px-3 py-2 text-left font-semibold text-gray-600">Updated</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {items.length === 0 ? (
+                <tr>
+                  <td className="px-3 py-4 text-center" colSpan={6}>
+                    対象の候補がありません。
+                  </td>
+                </tr>
+              ) : (
+                items.map(item => (
+                  <tr
+                    key={item.id}
+                    className="cursor-pointer hover:bg-gray-50"
+                    onClick={() => handleRowClick(item.id)}
+                  >
+                    <td className="px-3 py-2">{item.id}</td>
+                    <td className="px-3 py-2">{item.status}</td>
+                    <td className="px-3 py-2">{item.name_raw}</td>
+                    <td className="px-3 py-2">{item.source?.title ?? "-"}</td>
+                    <td className="px-3 py-2">{formatDateTime(item.fetched_at ?? null)}</td>
+                    <td className="px-3 py-2">{formatDateTime(item.updated_at)}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-500">件数: {items.length}</p>
+        <button
+          type="button"
+          className="rounded border border-gray-300 px-4 py-2 text-sm"
+          onClick={handleNext}
+          disabled={!nextCursor || loading}
+        >
+          次へ
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return <div className="mx-auto w-full max-w-6xl p-6">{children}</div>;
+}

--- a/frontend/app/admin/login/page.tsx
+++ b/frontend/app/admin/login/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const [token, setToken] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = token.trim();
+    if (!trimmed) {
+      setError("トークンを入力してください");
+      return;
+    }
+    const expires = new Date();
+    expires.setDate(expires.getDate() + 7);
+    document.cookie = `admin_token=${encodeURIComponent(trimmed)}; path=/; max-age=${7 * 24 * 60 * 60}`;
+    setError(null);
+    router.push("/admin/candidates");
+    router.refresh();
+  };
+
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-md flex-col justify-center gap-6 p-6">
+      <h1 className="text-2xl font-semibold">Admin Login</h1>
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-4 rounded-md border border-gray-200 p-6 shadow-sm"
+      >
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-gray-700">アクセス用トークン</span>
+          <input
+            type="password"
+            className="rounded border border-gray-300 px-3 py-2"
+            value={token}
+            onChange={event => setToken(event.target.value)}
+            placeholder="ADMIN_UI_TOKEN"
+            autoFocus
+          />
+        </label>
+        {error ? <p className="text-sm text-red-600">{error}</p> : null}
+        <button
+          type="submit"
+          className="rounded bg-black px-4 py-2 text-white transition hover:bg-gray-800"
+        >
+          ログイン
+        </button>
+      </form>
+      <p className="text-sm text-gray-600">
+        .env に設定された <code>ADMIN_UI_TOKEN</code> と一致する値を入力してください。
+      </p>
+    </div>
+  );
+}

--- a/frontend/lib/adminApi.ts
+++ b/frontend/lib/adminApi.ts
@@ -1,0 +1,287 @@
+import { ApiError, getApiBaseUrl } from "@/lib/apiClient";
+
+const MAX_RETRY_ATTEMPTS = 8;
+const BASE_BACKOFF_MS = 500;
+
+type JsonRecord = Record<string, unknown>;
+
+type RequestOptions = RequestInit & {
+  query?: Record<string, unknown>;
+};
+
+const getAdminToken = (): string | null => {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const match = document.cookie.match(/(?:^|; )admin_token=([^;]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+};
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const buildQueryString = (query: Record<string, unknown> | undefined) => {
+  if (!query) {
+    return "";
+  }
+  const params = new URLSearchParams();
+  Object.entries(query).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") {
+      return;
+    }
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        params.set(key, value.join(","));
+      }
+      return;
+    }
+    params.set(key, String(value));
+  });
+  const serialized = params.toString();
+  return serialized ? `?${serialized}` : "";
+};
+
+const parseRetryAfterHeader = (value: string | null): number | null => {
+  if (!value) {
+    return null;
+  }
+  const seconds = Number(value);
+  if (!Number.isNaN(seconds)) {
+    return Math.max(0, seconds) * 1000;
+  }
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+  const delay = timestamp - Date.now();
+  return delay > 0 ? delay : 0;
+};
+
+export class AdminApiError extends ApiError {
+  constructor(
+    message: string,
+    status?: number,
+    public readonly detail?: unknown,
+  ) {
+    super(message, status, detail);
+    this.name = "AdminApiError";
+  }
+}
+
+async function request<TResponse>(path: string, { query, headers, ...init }: RequestOptions = {}) {
+  const baseUrl = getApiBaseUrl();
+  const url = `${baseUrl}${path}${buildQueryString(query)}`;
+  const finalHeaders = new Headers({
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  });
+  if (headers) {
+    const provided = new Headers(headers as HeadersInit);
+    provided.forEach((value, key) => {
+      finalHeaders.set(key, value);
+    });
+  }
+  if (!finalHeaders.has("Authorization")) {
+    const token = getAdminToken();
+    if (token) {
+      finalHeaders.set("Authorization", `Bearer ${token}`);
+    }
+  }
+
+  for (let attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt += 1) {
+    const response = await fetch(url, {
+      ...init,
+      headers: finalHeaders,
+      credentials: init.credentials ?? "include",
+    });
+
+    if (response.status === 429) {
+      const retryAfter = parseRetryAfterHeader(response.headers.get("Retry-After"));
+      const fallbackDelay = BASE_BACKOFF_MS * 2 ** attempt;
+      const delay = retryAfter ?? fallbackDelay;
+      if (attempt === MAX_RETRY_ATTEMPTS - 1) {
+        const text = await response.text().catch(() => "Too Many Requests");
+        throw new AdminApiError(text || "Too Many Requests", 429);
+      }
+      await sleep(delay);
+      continue;
+    }
+
+    if (!response.ok) {
+      let detail: unknown;
+      let message = response.statusText;
+      const contentType = response.headers.get("Content-Type") ?? "";
+      if (contentType.includes("application/json")) {
+        detail = await response.json().catch(() => undefined);
+        if (detail && typeof detail === "object" && "detail" in detail) {
+          const detailMessage = (detail as { detail?: unknown }).detail;
+          if (typeof detailMessage === "string") {
+            message = detailMessage;
+          }
+        }
+      } else {
+        message = await response.text().catch(() => response.statusText);
+      }
+      throw new AdminApiError(message || "Request failed", response.status, detail);
+    }
+
+    if (response.status === 204) {
+      return undefined as TResponse;
+    }
+
+    const contentType = response.headers.get("Content-Type") ?? "";
+    if (contentType.includes("application/json")) {
+      return (await response.json()) as TResponse;
+    }
+    const text = await response.text();
+    return JSON.parse(text) as TResponse;
+  }
+
+  throw new AdminApiError("Request retry limit reached", 429);
+}
+
+export interface AdminSourceRef {
+  id: number;
+  title?: string | null;
+  url?: string | null;
+}
+
+export interface AdminCandidateItem {
+  id: number;
+  status: string;
+  name_raw: string;
+  address_raw?: string | null;
+  pref_slug?: string | null;
+  city_slug?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  parsed_json?: JsonRecord | null;
+  source: AdminSourceRef;
+  fetched_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ScrapedPageInfo {
+  url: string;
+  fetched_at: string;
+  http_status?: number | null;
+}
+
+export interface SimilarGymInfo {
+  gym_id: number;
+  gym_slug: string;
+  gym_name: string;
+}
+
+export interface AdminCandidateDetail extends AdminCandidateItem {
+  scraped_page: ScrapedPageInfo;
+  similar?: SimilarGymInfo[] | null;
+}
+
+export interface AdminCandidateListResponse {
+  items: AdminCandidateItem[];
+  next_cursor?: string | null;
+  count: number;
+}
+
+export interface AdminCandidateListParams {
+  status?: string | null;
+  source?: string | null;
+  q?: string | null;
+  pref?: string | null;
+  city?: string | null;
+  cursor?: string | null;
+  limit?: number;
+}
+
+export interface AdminCandidatePatchPayload {
+  name_raw?: string | null;
+  address_raw?: string | null;
+  pref_slug?: string | null;
+  city_slug?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  parsed_json?: JsonRecord | null;
+}
+
+export interface EquipmentAssign {
+  slug: string;
+  availability?: "present" | "absent" | "unknown";
+  count?: number | null;
+  max_weight_kg?: number | null;
+}
+
+export interface ApproveOverride {
+  name?: string | null;
+  pref_slug?: string | null;
+  city_slug?: string | null;
+  address?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+export interface ApproveRequestPayload {
+  dry_run: boolean;
+  override?: ApproveOverride | null;
+  equipments?: EquipmentAssign[] | null;
+}
+
+export interface GymUpsertPreview {
+  slug: string;
+  name: string;
+  canonical_id: string;
+  pref_slug?: string | null;
+  city_slug?: string | null;
+  address?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+export interface EquipmentUpsertSummary {
+  inserted: number;
+  updated: number;
+  total: number;
+}
+
+export interface ApproveSummary {
+  gym: GymUpsertPreview;
+  equipments: EquipmentUpsertSummary;
+}
+
+export interface ApprovePreviewResponse {
+  preview: ApproveSummary;
+}
+
+export interface ApproveResultResponse {
+  result: ApproveSummary;
+}
+
+export interface RejectRequestPayload {
+  reason: string;
+}
+
+export const listCandidates = (params: AdminCandidateListParams = {}) =>
+  request<AdminCandidateListResponse>("/admin/candidates", {
+    query: params,
+  });
+
+export const getCandidate = (id: number) =>
+  request<AdminCandidateDetail>(`/admin/candidates/${id}`);
+
+export const patchCandidate = (id: number, payload: AdminCandidatePatchPayload) =>
+  request<AdminCandidateItem>(`/admin/candidates/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+
+export const approveCandidate = (id: number, payload: ApproveRequestPayload) =>
+  request<ApprovePreviewResponse | ApproveResultResponse>(`/admin/candidates/${id}/approve`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+export const rejectCandidate = (id: number, payload: RejectRequestPayload) =>
+  request<AdminCandidateItem>(`/admin/candidates/${id}/reject`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const ADMIN_PREFIX = "/admin";
+const LOGIN_PATH = "/admin/login";
+
+const getTokenFromAuthorization = (header: string | null) => {
+  if (!header) {
+    return null;
+  }
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? (match[1]?.trim() ?? null) : null;
+};
+
+const isAdminPath = (pathname: string) =>
+  pathname === ADMIN_PREFIX || pathname.startsWith(`${ADMIN_PREFIX}/`);
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  if (!isAdminPath(pathname) || pathname === LOGIN_PATH) {
+    return NextResponse.next();
+  }
+
+  const requiredToken = process.env.ADMIN_UI_TOKEN?.trim();
+  if (!requiredToken) {
+    return NextResponse.next();
+  }
+
+  const cookieToken = request.cookies.get("admin_token")?.value;
+  const headerToken = getTokenFromAuthorization(request.headers.get("authorization"));
+  if (cookieToken === requiredToken || headerToken === requiredToken) {
+    return NextResponse.next();
+  }
+
+  const loginUrl = request.nextUrl.clone();
+  loginUrl.pathname = LOGIN_PATH;
+  const response = NextResponse.redirect(loginUrl, { status: 307 });
+  response.headers.set("x-admin-auth", "unauthorized");
+  return response;
+}
+
+export const config = {
+  matcher: ["/admin/:path*"],
+};


### PR DESCRIPTION
## 目的
- `/admin/candidates` の審査フローをフロントで完結できるようにするため

## 変更点
- ADMIN_UI_TOKEN による `/admin` 配下の認証ミドルウェアを追加
- `/admin/candidates` の一覧・詳細 UI を実装（dry-run 承認、本承認、却下に対応）
- 管理 API クライアントを新設し、429 の Retry-After リトライなどエラーハンドリングを実装
- README に Admin UI の利用方法を追記

## 確認手順
- [ ] `npm --prefix frontend run dev`
- [ ] `/admin/login` にアクセスし、`ADMIN_UI_TOKEN` を入力すると一覧が表示されること
- [ ] 候補詳細で dry-run、本承認、却下が実行できること

## CI
- [x] `npm --prefix frontend run lint`
- [x] `npm --prefix frontend run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68dde28ce014832a836d577d364318cc