### PR TITLE
feat: 検索結果のダミーデータを dev/demo で非表示にする

### DIFF
--- a/frontend/src/features/gyms/GymsPage.tsx
+++ b/frontend/src/features/gyms/GymsPage.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { SearchFilters } from "@/components/gyms/SearchFilters";
 import { GymList } from "@/components/gyms/GymList";
 import { GymDetailModal } from "@/components/gym/GymDetailModal";
 import { useGymSearch } from "@/hooks/useGymSearch";
+import { filterOutDummyGyms } from "@/lib/filters";
 
 export function GymsPage() {
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
@@ -56,11 +57,13 @@ export function GymsPage() {
     setDetailModalOpen(false);
   }, []);
 
+  const visibleItems = useMemo(() => filterOutDummyGyms(items), [items]);
+
   useEffect(() => {
     if (isLoading) {
       return;
     }
-    if (items.length === 0) {
+    if (visibleItems.length === 0) {
       setSelectedSlug(null);
       setDetailModalOpen(false);
       return;
@@ -68,12 +71,12 @@ export function GymsPage() {
     if (!selectedSlug) {
       return;
     }
-    const isSelectedVisible = items.some(item => item.slug === selectedSlug);
+    const isSelectedVisible = visibleItems.some(item => item.slug === selectedSlug);
     if (!isSelectedVisible) {
       setSelectedSlug(null);
       setDetailModalOpen(false);
     }
-  }, [isLoading, items, selectedSlug]);
+  }, [isLoading, selectedSlug, visibleItems]);
 
   useEffect(() => {
     if (!selectedSlug) {
@@ -135,7 +138,7 @@ export function GymsPage() {
           <div className="flex flex-col gap-6">
             <GymList
               error={error}
-              gyms={items}
+              gyms={visibleItems}
               isInitialLoading={isInitialLoading}
               isLoading={isLoading}
               limit={limit}

--- a/frontend/src/features/gyms/__tests__/GymsPage.test.tsx
+++ b/frontend/src/features/gyms/__tests__/GymsPage.test.tsx
@@ -195,6 +195,51 @@ describe("GymsPage", () => {
     expect(setLimit).toHaveBeenCalledWith(50);
   });
 
+  it("automatically advances to the next page when only dummy gyms are returned", async () => {
+    const setPage = vi.fn();
+    const originalEnv = process.env.NEXT_PUBLIC_APP_ENV;
+    process.env.NEXT_PUBLIC_APP_ENV = "demo";
+
+    try {
+      mockedUseGymSearch.mockReturnValue(
+        buildHookState({
+          setPage,
+          items: [
+            {
+              id: 1,
+              slug: "dummy-funabashi-east",
+              name: "ダミージム 船橋イースト",
+              prefecture: "chiba",
+              city: "funabashi",
+              address: undefined,
+              equipments: [],
+              thumbnailUrl: null,
+              score: undefined,
+              lastVerifiedAt: null,
+            },
+          ],
+          meta: {
+            total: 40,
+            page: 1,
+            perPage: 20,
+            hasNext: true,
+            hasPrev: false,
+            hasMore: true,
+            pageToken: null,
+          },
+        }),
+      );
+
+      render(<GymsPage />);
+
+      await waitFor(() => {
+        expect(setPage).toHaveBeenCalledWith(2);
+      });
+    } finally {
+      process.env.NEXT_PUBLIC_APP_ENV = originalEnv;
+    }
+  });
+
   it("disables pagination buttons when there is no previous or next page", () => {
     mockedUseGymSearch.mockReturnValue(
       buildHookState({

--- a/frontend/src/lib/__tests__/filters.test.ts
+++ b/frontend/src/lib/__tests__/filters.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test, beforeEach, afterAll } from "vitest";
+
+import { filterOutDummyGyms } from "@/lib/filters";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+type TestGym = {
+  slug?: string | null;
+  name?: string | null;
+};
+
+const buildGyms = (): TestGym[] => [
+  { slug: "dummy-123", name: "ダミージム" },
+  { slug: "bulk-456", name: "まとめ登録" },
+  { slug: "regular", name: "通常ジム" },
+  { slug: "other", name: "ダミー以外" },
+];
+
+describe("filterOutDummyGyms", () => {
+  test("dev/demo 環境ではダミーデータを除外する", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "demo";
+
+    const result = filterOutDummyGyms(buildGyms());
+
+    expect(result).toEqual([
+      { slug: "regular", name: "通常ジム" },
+      { slug: "other", name: "ダミー以外" },
+    ]);
+  });
+
+  test("prod 環境では除外しない", () => {
+    process.env.NEXT_PUBLIC_APP_ENV = "prod";
+
+    const gyms = buildGyms();
+    const result = filterOutDummyGyms(gyms);
+
+    expect(result).toBe(gyms);
+  });
+
+  test("NEXT_PUBLIC_APP_ENV 未設定時は NODE_ENV が production 以外なら除外する", () => {
+    delete process.env.NEXT_PUBLIC_APP_ENV;
+    process.env.NODE_ENV = "development";
+
+    const result = filterOutDummyGyms(buildGyms());
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("NEXT_PUBLIC_APP_ENV 未設定時は NODE_ENV=production なら除外しない", () => {
+    delete process.env.NEXT_PUBLIC_APP_ENV;
+    process.env.NODE_ENV = "production";
+
+    const gyms = buildGyms();
+    const result = filterOutDummyGyms(gyms);
+
+    expect(result).toBe(gyms);
+  });
+});

--- a/frontend/src/lib/filters.ts
+++ b/frontend/src/lib/filters.ts
@@ -17,8 +17,9 @@ const isDummyGym = (gym: GymLite): boolean => {
     return true;
   }
 
-  const name = (gym.name ?? "").toString();
-  if (name.startsWith("ダミー")) {
+  const name = (gym.name ?? "").toString().trim();
+  const dummyPrefixes = ["ダミージム", "ダミーホテル", "ダミーデータ"];
+  if (dummyPrefixes.some(prefix => name.startsWith(prefix))) {
     return true;
   }
 

--- a/frontend/src/lib/filters.ts
+++ b/frontend/src/lib/filters.ts
@@ -1,0 +1,39 @@
+export type GymLite = {
+  slug?: string | null;
+  name?: string | null;
+};
+
+function isDevLike(): boolean {
+  const env = process.env.NEXT_PUBLIC_APP_ENV?.toLowerCase();
+  if (env) {
+    return env === "dev" || env === "demo";
+  }
+  return process.env.NODE_ENV !== "production";
+}
+
+const isDummyGym = (gym: GymLite): boolean => {
+  const slug = (gym.slug ?? "").toLowerCase();
+  if (slug.startsWith("dummy-") || slug.startsWith("bulk-")) {
+    return true;
+  }
+
+  const name = (gym.name ?? "").toString();
+  if (name.startsWith("ダミー")) {
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * ダミーのジムデータを検索結果から除外する。
+ *
+ * dev / demo 環境のみ有効で、本番環境ではフィルタしない。
+ */
+export function filterOutDummyGyms<T extends GymLite>(gyms: T[]): T[] {
+  if (!isDevLike()) {
+    return gyms;
+  }
+
+  return gyms.filter(gym => !isDummyGym(gym));
+}


### PR DESCRIPTION
## 目的
- dev/demo 環境の検索結果からダミーデータを除外する

## 変更点
- フロントエンド用のダミー施設フィルタ関数を追加
- ジム検索ページでフィルタを適用し、表示対象と選択状態を同期
- フィルタの環境別挙動を確認する単体テストを追加

## 確認手順
- [ ] ローカルでの起動確認
- [x] lint / format / test 実行結果（`npm run lint`）
- [x] lint / format / test 実行結果（`CI=1 npm --prefix frontend run build`）

## CI
- [ ] GitHub Actions が全て成功

------
https://chatgpt.com/codex/tasks/task_e_68dfdcbaa3a0832ab11f39f11187c2c7