### PR TITLE
feat: 自治体スクレイプ共通ヘルパーの追加

### DIFF
--- a/scripts/ingest/sites/_municipal_base.py
+++ b/scripts/ingest/sites/_municipal_base.py
@@ -1,0 +1,184 @@
+"""Common helpers for municipal facility scrapers."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Iterable
+from typing import Final
+from urllib.parse import urljoin, urlsplit, urlunsplit
+
+from bs4 import BeautifulSoup
+
+_FULLWIDTH_HYPHENS: Final[tuple[str, ...]] = (
+    "−",
+    "‐",
+    "―",
+    "ー",
+    "ｰ",
+    "–",
+    "—",
+    "─",
+)
+
+_POSTAL_CODE_RE: Final[re.Pattern[str]] = re.compile(r"〒?\s*(\d{3})[\-‐‑‒–—―−ーｰ－‐]?(\d{4})")
+_ADDRESS_RE: Final[re.Pattern[str]] = re.compile(
+    r"((?:東京都|北海道|(?:京都|大阪)府|[\wぁ-んァ-ヶ一-龯]{2,3}県)?[^\n]{0,30}(?:市|区|郡|町|村)[^\n]*?\d[^\n]*)"
+)
+_TEL_RE: Final[re.Pattern[str]] = re.compile(r"0\d{1,4}[\-\(（]??\d{1,4}[\-\)）]?\d{3,4}")
+_IGNORE_URLS: Final[set[str]] = {"", "#", "#top", "javascript:void(0)", "javascript:;"}
+_IGNORE_PREFIXES: Final[tuple[str, ...]] = ("javascript:",)
+
+
+def normalize_text(value: str | None) -> str:
+    """Return text normalized to NFC, without NULs, and compacted whitespace."""
+
+    if not value:
+        return ""
+    normalized = unicodedata.normalize("NFKC", value).replace("\x00", "")
+    normalized = normalized.replace("\u3000", " ")
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.strip()
+
+
+def absolutize_url(base: str | None, href: str | None) -> str:
+    """Convert *href* to an absolute URL using *base* when available."""
+
+    if not href:
+        return ""
+    href = href.strip()
+    if not href or href in _IGNORE_URLS:
+        return ""
+    if href.startswith(("mailto:", "tel:")):
+        return href
+    if href.startswith(_IGNORE_PREFIXES):
+        return ""
+    return urljoin(base or "", href)
+
+
+def extract_links(html: str | None, base_url: str | None = None) -> list[str]:
+    """Return unique non-anchor links from *html*, resolved from *base_url*."""
+
+    soup = BeautifulSoup(html or "", "html.parser")
+    results: list[str] = []
+    seen: set[str] = set()
+    for tag in soup.find_all("a"):
+        href = tag.get("href")
+        url = absolutize_url(base_url, href)
+        if not url:
+            continue
+        canonical = _canonicalize_url(url)
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        results.append(canonical)
+    return results
+
+
+def extract_address(source: str | None) -> tuple[str | None, str | None]:
+    """Extract an address and postal code tuple from HTML or plain text."""
+
+    if not source:
+        return None, None
+    soup = BeautifulSoup(source, "html.parser")
+
+    candidates: list[str] = []
+    for tag in soup.find_all(["address", "p", "li", "dd", "dt", "td", "span", "div"]):
+        text = normalize_text(tag.get_text(" ", strip=True))
+        if text:
+            candidates.append(text)
+    full_text = normalize_text(soup.get_text("\n", strip=True))
+    if full_text:
+        candidates.append(full_text)
+    raw_text = normalize_text(source)
+    if raw_text:
+        candidates.append(raw_text)
+
+    postal_code = None
+    address = None
+    for text in candidates:
+        if not postal_code and (match := _POSTAL_CODE_RE.search(text)):
+            postal_code = f"{match.group(1)}-{match.group(2)}"
+        if not address and (match := _ADDRESS_RE.search(text)):
+            address = match.group(1)
+        if address and postal_code:
+            break
+    return address, postal_code
+
+
+def extract_tel(source: str | None) -> list[str]:
+    """Extract telephone numbers from *source* text or HTML."""
+
+    if not source:
+        return []
+    soup = BeautifulSoup(source, "html.parser")
+    text = normalize_text(soup.get_text(" ", strip=True))
+    matches = _TEL_RE.findall(text)
+    results: list[str] = []
+    seen: set[str] = set()
+    for match in matches:
+        tel = _normalize_tel(match)
+        if tel and tel not in seen:
+            seen.add(tel)
+            results.append(tel)
+    return results
+
+
+def dedupe_urls(urls: Iterable[str | None]) -> list[str]:
+    """Remove duplicates and boilerplate placeholders from *urls*."""
+
+    results: list[str] = []
+    seen: set[str] = set()
+    for url in urls:
+        if not url:
+            continue
+        cleaned = normalize_text(url)
+        if not cleaned or cleaned in _IGNORE_URLS:
+            continue
+        if cleaned.startswith(_IGNORE_PREFIXES):
+            continue
+        canonical = _canonicalize_url(cleaned)
+        if not canonical or canonical in seen:
+            continue
+        seen.add(canonical)
+        results.append(canonical)
+    return results
+
+
+def _canonicalize_url(url: str) -> str:
+    split = urlsplit(url)
+    fragment = split.fragment.lower()
+    if fragment in {"", "top", "header", "main"}:
+        split = split._replace(fragment="")
+    canonical = urlunsplit(split)
+    if canonical.endswith("/") and split.path not in {"/", ""}:
+        canonical = canonical.rstrip("/")
+    return canonical
+
+
+def _normalize_tel(value: str) -> str:
+    digits = re.sub(r"\D", "", value)
+    if len(digits) == 11:
+        return f"{digits[:3]}-{digits[3:7]}-{digits[7:]}"
+    if len(digits) == 10:
+        if digits.startswith(("03", "06")):
+            return f"{digits[:2]}-{digits[2:6]}-{digits[6:]}"
+        return f"{digits[:3]}-{digits[3:6]}-{digits[6:]}"
+    if len(digits) == 9:
+        return f"{digits[:2]}-{digits[2:5]}-{digits[5:]}"
+    normalized = value
+    for hyphen in _FULLWIDTH_HYPHENS:
+        normalized = normalized.replace(hyphen, "-")
+    normalized = normalized.replace("(", "").replace(")", "")
+    normalized = re.sub(r"-+", "-", normalized)
+    return normalized.strip("-")
+
+
+__all__ = [
+    "normalize_text",
+    "absolutize_url",
+    "extract_links",
+    "extract_address",
+    "extract_tel",
+    "dedupe_urls",
+]

--- a/scripts/ingest/sites/municipal_koto.py
+++ b/scripts/ingest/sites/municipal_koto.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import re
-import unicodedata
 from collections.abc import Iterable
 from typing import Any, Final
 
 from bs4 import BeautifulSoup
+
+from ._municipal_base import extract_address, normalize_text
 
 SITE_ID: Final[str] = "municipal_koto"
 ALLOWED_HOSTS: Final[tuple[str, ...]] = ("www.koto-hsc.or.jp",)
@@ -167,18 +168,9 @@ def seed_pages(limit: int | None = None) -> list[tuple[str, str]]:
     return pages
 
 
-def _norm(value: str | None) -> str:
-    if not value:
-        return ""
-    return unicodedata.normalize("NFKC", value).replace("\x00", "").strip()
-
-
 _ADDRESS_LABELS: Final[tuple[str, ...]] = ("所在地", "住所")
 _ADDRESS_TAGS: Final[tuple[str, ...]] = ("dt", "dd", "th", "td", "p", "li", "span", "div")
 _BREADCRUMB_TAGS: Final[tuple[str, ...]] = ("nav", "ol", "ul", "h2", "h3", "h4", "h5")
-_ADDRESS_REGEX: Final[re.Pattern[str]] = re.compile(
-    r"(東京都[^\n]+?区[^\n]+?\d[\d\-－ー丁目番地号]*|江東区[^\n]+?\d[\d\-－ー丁目番地号]*)"
-)
 
 
 def parse_detail(html: str) -> dict[str, str | list[str] | None]:
@@ -190,19 +182,19 @@ def parse_detail(html: str) -> dict[str, str | list[str] | None]:
     if h1 := soup.find("h1"):
         text = h1.get_text(" ", strip=True)
         if text:
-            name = _norm(text)
+            name = normalize_text(text)
     if not name and soup.title:
         title_text = soup.title.get_text(" ", strip=True)
-        name = _norm(title_text)
+        name = normalize_text(title_text)
 
     address = ""
     if address_tag := soup.find("address"):
         text = address_tag.get_text(" ", strip=True)
-        address = _norm(text)
+        address = normalize_text(text)
     if not address:
         # Labels such as 所在地 / 住所 that accompany a nearby value.
         for tag in soup.find_all(_ADDRESS_TAGS):
-            raw_text = _norm(tag.get_text(" ", strip=True))
+            raw_text = normalize_text(tag.get_text(" ", strip=True))
             if not raw_text:
                 continue
             for label in _ADDRESS_LABELS:
@@ -210,7 +202,7 @@ def parse_detail(html: str) -> dict[str, str | list[str] | None]:
                     continue
                 # Try to extract the value embedded in the same element.
                 candidate = re.sub(rf"^{re.escape(label)}\s*[:：\-－\|｜]*", "", raw_text)
-                candidate = _norm(candidate)
+                candidate = normalize_text(candidate)
                 if _looks_like_address(candidate):
                     address = candidate
                     break
@@ -221,14 +213,13 @@ def parse_detail(html: str) -> dict[str, str | list[str] | None]:
             if address:
                 break
     if not address:
-        # Regex based extraction from the whole text content.
-        text_blob = soup.get_text("\n", strip=True)
-        if match := _ADDRESS_REGEX.search(text_blob):
-            address = _norm(match.group(0))
+        extracted_address, _postal = extract_address(html)
+        if extracted_address:
+            address = normalize_text(extracted_address)
     if not address:
         # Breadcrumb or heading that at least indicates the ward.
         for crumb in soup.find_all(_BREADCRUMB_TAGS):
-            crumb_text = _norm(crumb.get_text(" ", strip=True))
+            crumb_text = normalize_text(crumb.get_text(" ", strip=True))
             if "江東区" in crumb_text:
                 address = crumb_text
                 break
@@ -236,19 +227,19 @@ def parse_detail(html: str) -> dict[str, str | list[str] | None]:
         text = soup.get_text("\n", strip=True)
         for line in text.splitlines():
             if "〒" in line or "東京都" in line:
-                address = _norm(line)
+                address = normalize_text(line)
                 if address:
                     break
 
     equipments_raw: list[str] = []
     keywords = ("トレーニング", "マシン", "ダンベル", "スミス", "ベンチ", "ラット")
     for li in soup.select("ul li"):
-        value = _norm(li.get_text(" ", strip=True))
+        value = normalize_text(li.get_text(" ", strip=True))
         if value and any(keyword in value for keyword in keywords):
             equipments_raw.append(value)
     if not equipments_raw:
         for paragraph in soup.select("p"):
-            value = _norm(paragraph.get_text(" ", strip=True))
+            value = normalize_text(paragraph.get_text(" ", strip=True))
             if value and any(keyword in value for keyword in keywords):
                 equipments_raw.append(value)
 
@@ -291,7 +282,7 @@ def _extract_sibling_value(tag: object) -> str:
     for sibling_name in sibling_tags.get(tag_name, ("dd", "td")):
         sibling = tag.find_next_sibling(sibling_name) if sibling_name else None
         if sibling:
-            candidate = _norm(sibling.get_text(" ", strip=True))
+            candidate = normalize_text(sibling.get_text(" ", strip=True))
             if _looks_like_address(candidate):
                 return candidate
             if candidate:


### PR DESCRIPTION
## 目的
- 自治体向けスクレイパーで共通利用できるヘルパーを整備して横展開コストを削減する

## 変更点
- 自治体スクレイプ用の共通ヘルパー `_municipal_base.py` を新規追加
- 江東区スクレイパーで共通ヘルパーを利用するように実装を整理

## 確認手順
- [ ] ローカルでの起動確認
- [x] lint / format / test 実行結果（`ruff format`, `ruff check`）

## CI
- [ ] GitHub Actions が全て成功

------
https://chatgpt.com/codex/tasks/task_e_68dff47c50fc832aa8f934ce7cfc5dbd