### PR TITLE
feat: 江戸川区向けスクレイパーの追加

### DIFF
--- a/scripts/ingest/fetch.py
+++ b/scripts/ingest/fetch.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from app.db import SessionLocal
 from app.models.scraped_page import ScrapedPage
 
-from .sites import municipal_koto, municipal_sumida, site_a
+from .sites import municipal_edogawa, municipal_koto, municipal_sumida, site_a
 from .utils import get_or_create_source
 
 logger = logging.getLogger(__name__)
@@ -174,6 +174,22 @@ async def _fetch_municipal_sumida(source: str, limit: int | None, file_path: Pat
     return 0
 
 
+async def _fetch_municipal_edogawa(source: str, limit: int | None, file_path: Path | None) -> int:
+    if file_path is not None:
+        msg = "File input is not supported for source 'municipal_edogawa'"
+        raise ValueError(msg)
+
+    raw_entries = municipal_edogawa.iter_seed_pages(limit)
+    if not raw_entries:
+        logger.info("No URLs provided; nothing to fetch for source '%s'", source)
+        return 0
+
+    entries = [(str(url), str(html)) for url, html in raw_entries]
+    created, updated = await _upsert_scraped_pages(source, entries)
+    _log_fetch_summary(source, entries, created, updated)
+    return 0
+
+
 async def fetch_pages(source: str, limit: int | None, file_path: Path | None) -> int:
     """Fetch HTML pages for the requested ingest ``source``."""
 
@@ -185,5 +201,7 @@ async def fetch_pages(source: str, limit: int | None, file_path: Path | None) ->
         return await _fetch_municipal_koto(source, limit, file_path)
     if source == municipal_sumida.SITE_ID:
         return await _fetch_municipal_sumida(source, limit, file_path)
+    if source == municipal_edogawa.SITE_ID:
+        return await _fetch_municipal_edogawa(source, limit, file_path)
     msg = f"Unsupported source: {source}"
     raise ValueError(msg)

--- a/scripts/ingest/normalize.py
+++ b/scripts/ingest/normalize.py
@@ -13,7 +13,7 @@ from app.models.equipment import Equipment
 from app.models.gym_candidate import GymCandidate
 from app.models.scraped_page import ScrapedPage
 
-from .sites import municipal_koto, municipal_sumida, site_a
+from .sites import municipal_edogawa, municipal_koto, municipal_sumida, site_a
 from .utils import get_or_create_source
 
 logger = logging.getLogger(__name__)
@@ -107,17 +107,25 @@ _MUNICIPAL_SUMIDA_PREF_MAP = {
 _MUNICIPAL_SUMIDA_CITY_MAP = {
     "墨田区": "sumida",
 }
+_MUNICIPAL_EDOGAWA_PREF_MAP = {
+    "東京都": "tokyo",
+}
+_MUNICIPAL_EDOGAWA_CITY_MAP = {
+    "江戸川区": "edogawa",
+}
 _PREF_MAPS = {
     "dummy": _DUMMY_PREF_MAP,
     site_a.SITE_ID: _SITE_A_PREF_MAP,
     municipal_koto.SITE_ID: _MUNICIPAL_KOTO_PREF_MAP,
     municipal_sumida.SITE_ID: _MUNICIPAL_SUMIDA_PREF_MAP,
+    municipal_edogawa.SITE_ID: _MUNICIPAL_EDOGAWA_PREF_MAP,
 }
 _CITY_MAPS = {
     "dummy": _DUMMY_CITY_MAP,
     site_a.SITE_ID: _SITE_A_CITY_MAP,
     municipal_koto.SITE_ID: _MUNICIPAL_KOTO_CITY_MAP,
     municipal_sumida.SITE_ID: _MUNICIPAL_SUMIDA_CITY_MAP,
+    municipal_edogawa.SITE_ID: _MUNICIPAL_EDOGAWA_CITY_MAP,
 }
 
 

--- a/scripts/ingest/sites/__init__.py
+++ b/scripts/ingest/sites/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
-from . import municipal_koto, municipal_sumida, site_a
+from . import municipal_edogawa, municipal_koto, municipal_sumida, site_a
 
-__all__ = ["site_a", "municipal_koto", "municipal_sumida"]
+__all__ = [
+    "site_a",
+    "municipal_koto",
+    "municipal_sumida",
+    "municipal_edogawa",
+]

--- a/scripts/ingest/sites/municipal_edogawa.py
+++ b/scripts/ingest/sites/municipal_edogawa.py
@@ -1,0 +1,178 @@
+"""Helpers for scraping Edogawa municipal sports facility pages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from bs4 import BeautifulSoup
+
+from ._municipal_base import (
+    absolutize_url,
+    dedupe_urls,
+    extract_address,
+    extract_links,
+    extract_tel,
+    normalize_text,
+)
+
+SITE_ID: Final[str] = "municipal_edogawa"
+BASE_URL: Final[str] = "https://www.city.edogawa.tokyo.jp"
+LISTING_PATH: Final[str] = "/e078/sports/trainingroom/index.html"
+LISTING_URL: Final[str] = f"{BASE_URL}{LISTING_PATH}"
+
+
+@dataclass(frozen=True, slots=True)
+class MunicipalEdogawaFacilitySeed:
+    """Seed data representing a mock Edogawa facility detail page."""
+
+    path: str
+    name: str
+    postal_code: str
+    address: str
+    tel: str
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class MunicipalEdogawaParsedFacility:
+    """Parsed fields extracted from an Edogawa facility detail HTML page."""
+
+    name: str
+    address: str
+    postal_code: str
+    tel: str
+    detail_url: str
+
+
+_FACILITY_SEEDS: Final[tuple[MunicipalEdogawaFacilitySeed, ...]] = (
+    MunicipalEdogawaFacilitySeed(
+        path="/e078/sports/trainingroom/sogo_sports_center.html",
+        name="江戸川区総合体育館 トレーニングルーム",
+        postal_code="132-0031",
+        address="東京都江戸川区松本1-35-1",
+        tel="03-3653-7441",
+        description="フリーウエイトと有酸素マシンを備えた総合体育館のトレーニングルームです。",
+    ),
+    MunicipalEdogawaFacilitySeed(
+        path="/e078/sports/trainingroom/tobu_health_support.html",
+        name="東部健康サポートセンター トレーニング室",
+        postal_code="132-0011",
+        address="東京都江戸川区瑞江2-5-7",
+        tel="03-3679-1305",
+        description="初心者講習とヘルスチェックを常設する地域密着型のトレーニング施設です。",
+    ),
+    MunicipalEdogawaFacilitySeed(
+        path="/e078/sports/trainingroom/shinozaki_plaza.html",
+        name="篠崎文化プラザ トレーニングルーム",
+        postal_code="133-0061",
+        address="東京都江戸川区篠崎町7-30-3",
+        tel="03-3670-9070",
+        description="マシントレーニングとスタジオプログラムを提供する文化プラザ内施設です。",
+    ),
+)
+
+
+def _build_listing_html() -> str:
+    items = "\n".join(
+        f'        <li><a href="{seed.path}">{seed.name}</a></li>' for seed in _FACILITY_SEEDS
+    )
+    return (
+        "<html>\n"
+        "  <body>\n"
+        '    <section class="facility-listing">\n'
+        "      <h1>江戸川区 トレーニングルーム一覧</h1>\n"
+        '      <ul class="facilities">\n'
+        f"{items}\n"
+        "      </ul>\n"
+        "    </section>\n"
+        "  </body>\n"
+        "</html>"
+    )
+
+
+_LISTING_HTML: Final[str] = _build_listing_html()
+
+
+def _render_detail_html(seed: MunicipalEdogawaFacilitySeed) -> str:
+    return (
+        "<html>\n"
+        "  <head>\n"
+        f"    <title>{seed.name}｜江戸川区スポーツ施設</title>\n"
+        "  </head>\n"
+        "  <body>\n"
+        '    <article class="facility-detail">\n'
+        f'      <h1 class="facility-name">{seed.name}</h1>\n'
+        '      <div class="facility-summary">\n'
+        f'        <p class="facility-description">{seed.description}</p>\n'
+        "      </div>\n"
+        '      <div class="facility-contact">\n'
+        f'        <p class="facility-postal">〒{seed.postal_code}</p>\n'
+        f'        <p class="facility-address">{seed.address}</p>\n'
+        f"        <address>〒{seed.postal_code} {seed.address}</address>\n"
+        f'        <p class="facility-tel">TEL：{seed.tel}</p>\n'
+        "      </div>\n"
+        "    </article>\n"
+        "  </body>\n"
+        "</html>"
+    )
+
+
+_FACILITY_HTML: Final[dict[str, str]] = {
+    absolutize_url(BASE_URL, seed.path): _render_detail_html(seed) for seed in _FACILITY_SEEDS
+}
+
+
+def iter_seed_pages(limit: int | None = None) -> list[tuple[str, str]]:
+    """Return mock facility detail pages discovered from the listing page."""
+
+    detail_urls = dedupe_urls(extract_links(_LISTING_HTML, LISTING_URL))
+    pages: list[tuple[str, str]] = []
+    for url in detail_urls:
+        html = _FACILITY_HTML.get(url)
+        if not html:
+            continue
+        pages.append((url, html))
+    if limit is not None:
+        return pages[: max(0, limit)]
+    return pages
+
+
+def parse(raw_html: str, *, url: str | None = None) -> MunicipalEdogawaParsedFacility:
+    """Parse an Edogawa facility detail HTML page."""
+
+    soup = BeautifulSoup(raw_html or "", "html.parser")
+
+    name = ""
+    if node := soup.select_one(".facility-name, h1"):
+        name = normalize_text(node.get_text(" ", strip=True))
+    if not name and soup.title:
+        name = normalize_text(soup.title.get_text(" ", strip=True))
+
+    address, postal_code = extract_address(raw_html)
+    address = normalize_text(address)
+    postal_code = normalize_text(postal_code)
+
+    tel_candidates = extract_tel(raw_html)
+    tel = normalize_text(tel_candidates[0]) if tel_candidates else ""
+
+    detail_url = normalize_text(url) if url else ""
+
+    return MunicipalEdogawaParsedFacility(
+        name=name,
+        address=address,
+        postal_code=postal_code,
+        tel=tel,
+        detail_url=detail_url,
+    )
+
+
+__all__ = [
+    "SITE_ID",
+    "BASE_URL",
+    "LISTING_URL",
+    "MunicipalEdogawaFacilitySeed",
+    "MunicipalEdogawaParsedFacility",
+    "iter_seed_pages",
+    "parse",
+]


### PR DESCRIPTION
## 目的
- 江戸川区サイトのスポーツ施設データ取得フローをモック環境で再現するため

## 変更点
- 江戸川区サイト用のスクレイプモジュールを新規実装し、一覧ページから詳細ページを列挙・解析できるようにした
- fetch / parse / normalize に municipal_edogawa 分岐を追加し、住所・郵便番号・TEL を含む JSON を生成するようにした

## 確認手順
- [ ] docker compose exec api python -m scripts.ingest fetch --source municipal_edogawa --limit 50
- [ ] docker compose exec api python -m scripts.ingest parse --source municipal_edogawa --limit 50
- [ ] docker compose exec api python -m scripts.ingest normalize --source municipal_edogawa --limit 50

## CI
- [ ] GitHub Actions が全て成功

------
https://chatgpt.com/codex/tasks/task_e_68e07b1e90bc832a8a5b92e4451a2571