### PR TITLE
feat: 管理画面向け手動候補入稿APIを追加

### DIFF
--- a/app/api/routers/admin_candidates.py
+++ b/app/api/routers/admin_candidates.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.deps import get_async_session
 from app.models.gym_candidate import CandidateStatus
 from app.schemas.admin_candidates import (
+    AdminCandidateCreate,
     AdminCandidateDetail,
     AdminCandidateItem,
     AdminCandidateListResponse,
@@ -72,6 +73,17 @@ def _to_detail(row: CandidateDetailRow) -> AdminCandidateDetail:
         scraped_page=scraped_page,
         similar=similar,
     )
+
+
+@router.post("", response_model=AdminCandidateItem, status_code=201)
+async def create_candidate(
+    payload: AdminCandidateCreate, session: AsyncSession = Depends(get_async_session)
+):
+    try:
+        row = await candidate_service.create_manual_candidate(session, payload)
+    except CandidateServiceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _to_item(row)
 
 
 @router.get("", response_model=AdminCandidateListResponse)

--- a/app/schemas/admin_candidates.py
+++ b/app/schemas/admin_candidates.py
@@ -47,6 +47,18 @@ class AdminCandidateDetail(AdminCandidateItem):
     similar: list[SimilarGymInfo] | None = None
 
 
+class AdminCandidateCreate(BaseModel):
+    name_raw: str
+    address_raw: str | None = None
+    pref_slug: str
+    city_slug: str
+    latitude: float | None = None
+    longitude: float | None = None
+    parsed_json: dict[str, Any] | None = None
+    official_url: str | None = None
+    equipments: list[EquipmentAssign] | None = None
+
+
 class AdminCandidatePatch(BaseModel):
     name_raw: str | None = None
     address_raw: str | None = None

--- a/tests/test_admin_candidates_manual_create.py
+++ b/tests/test_admin_candidates_manual_create.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Equipment, Gym, GymCandidate
+
+
+async def _ensure_equipment(session: AsyncSession, slug: str) -> None:
+    exists = await session.execute(select(Equipment).where(Equipment.slug == slug))
+    if exists.scalar_one_or_none() is None:
+        session.add(Equipment(slug=slug, name=slug.replace("-", " "), category="machine"))
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_manual_candidate_create_and_approve(
+    app_client: AsyncClient, session: AsyncSession
+) -> None:
+    await _ensure_equipment(session, "smith-machine")
+
+    official_url = "https://example.com/manual-gym"
+    payload = {
+        "name_raw": "手動ジム",
+        "address_raw": "東京都江東区",
+        "pref_slug": "tokyo",
+        "city_slug": "koto",
+        "latitude": 35.6,
+        "longitude": 139.8,
+        "official_url": official_url,
+        "equipments": [{"slug": "smith-machine", "availability": "present"}],
+    }
+
+    resp = await app_client.post("/admin/candidates", json=payload)
+    assert resp.status_code in {200, 201}
+    created = resp.json()
+    assert created["name_raw"] == payload["name_raw"]
+    assert created["pref_slug"] == payload["pref_slug"]
+    assert created["city_slug"] == payload["city_slug"]
+
+    candidate = await session.get(GymCandidate, created["id"])
+    assert candidate is not None
+    assert candidate.parsed_json is not None
+    assert candidate.parsed_json.get("official_url") == official_url
+
+    approve = await app_client.post(
+        f"/admin/candidates/{created['id']}/approve", json={"dry_run": False}
+    )
+    assert approve.status_code == 200
+
+    gym_result = await session.execute(select(Gym).where(Gym.official_url == official_url))
+    gym = gym_result.scalar_one_or_none()
+    assert gym is not None


### PR DESCRIPTION
## 目的
- 管理画面から手動でジム候補を登録できるようにする

## 変更点
- AdminCandidateCreate スキーマを追加し、公式URLや設備指定を受け取れるようにした
- 手動入稿用の候補生成サービスと `/admin/candidates` POST エンドポイントを実装
- 手動登録から承認までを確認するAPIテストを追加

## 確認手順
- [ ] ローカルでの起動確認
- [ ] lint / format / test 実行結果

## CI
- [ ] GitHub Actions が全て成功

------
https://chatgpt.com/codex/tasks/task_e_68e0919fc108832ab75c2a754b0b207d