### PR TITLE
feat: ジオコーディングキャッシュと欠損補完スクリプトを追加

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,6 +3,7 @@
 from .base import Base
 from .equipment import Equipment
 from .favorite import Favorite
+from .geocode_cache import GeocodeCache
 from .gym import Gym
 from .gym_candidate import CandidateStatus, GymCandidate
 from .gym_equipment import GymEquipment
@@ -17,6 +18,7 @@ __all__ = [
     "Gym",
     "Equipment",
     "GymEquipment",
+    "GeocodeCache",
     "GymSlug",
     "Source",
     "Report",

--- a/app/models/geocode_cache.py
+++ b/app/models/geocode_cache.py
@@ -1,0 +1,35 @@
+"""Geocode cache model."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, Float, String, Text
+from sqlalchemy.dialects.postgresql import BIGINT, JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class GeocodeCache(Base):
+    """Cache table for storing geocoding results."""
+
+    __tablename__ = "geocode_caches"
+
+    id: Mapped[int] = mapped_column(BIGINT, primary_key=True, autoincrement=True)
+    address: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    latitude: Mapped[float | None] = mapped_column(Float, nullable=True)
+    longitude: Mapped[float | None] = mapped_column(Float, nullable=True)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    raw: Mapped[dict[str, Any] | list[Any] | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/app/services/geocode.py
+++ b/app/services/geocode.py
@@ -1,0 +1,168 @@
+"""Geocoding utilities with local caching."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import unicodedata
+from typing import Any
+
+import requests
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.geocode_cache import GeocodeCache
+
+logger = logging.getLogger(__name__)
+
+_USER_AGENT = "gym-directory/0.1 (contact@example.com)"
+_RATE_LIMIT_SECONDS = 1.0
+_LAST_REQUEST_AT = 0.0
+_PROVIDER = "nominatim"
+
+
+def sanitize_address(address: str) -> str:
+    """Normalize addresses for consistent caching and lookup."""
+
+    normalized = unicodedata.normalize("NFKC", address or "")
+    cleaned = normalized.replace("\x00", "").strip()
+    return " ".join(cleaned.split())
+
+
+async def get_cached(session: AsyncSession, address: str) -> tuple[float, float] | None:
+    """Return cached latitude/longitude for an address if available."""
+
+    sanitized = sanitize_address(address)
+    if not sanitized:
+        return None
+
+    result = await session.execute(
+        select(GeocodeCache.latitude, GeocodeCache.longitude).where(
+            GeocodeCache.address == sanitized
+        )
+    )
+    row = result.one_or_none()
+    if row is None:
+        return None
+    latitude, longitude = row
+    if latitude is None or longitude is None:
+        return None
+    return float(latitude), float(longitude)
+
+
+async def put_cache(
+    session: AsyncSession,
+    address: str,
+    latitude: float | None,
+    longitude: float | None,
+    provider: str,
+    raw: Any,
+) -> None:
+    """Persist a geocode result in the cache table."""
+
+    sanitized = sanitize_address(address)
+    if not sanitized:
+        return
+
+    result = await session.execute(select(GeocodeCache).where(GeocodeCache.address == sanitized))
+    cache = result.scalar_one_or_none()
+    if cache is None:
+        cache = GeocodeCache(address=sanitized, provider=provider)
+        session.add(cache)
+
+    cache.latitude = latitude
+    cache.longitude = longitude
+    cache.provider = provider
+    if isinstance(raw, dict | list):
+        cache.raw = raw
+    else:
+        try:
+            cache.raw = json.loads(json.dumps(raw))
+        except (TypeError, ValueError):
+            cache.raw = None
+    await session.flush()
+
+
+def _enforce_rate_limit() -> None:
+    global _LAST_REQUEST_AT
+
+    now = time.monotonic()
+    wait = _RATE_LIMIT_SECONDS - (now - _LAST_REQUEST_AT)
+    if wait > 0:
+        time.sleep(wait)
+    _LAST_REQUEST_AT = time.monotonic()
+
+
+def nominatim_geocode(address: str) -> tuple[float, float, Any] | None:
+    """Lookup coordinates via the public Nominatim endpoint."""
+
+    sanitized = sanitize_address(address)
+    if not sanitized:
+        logger.info("skip: insufficient address (empty after sanitize)")
+        return None
+
+    _enforce_rate_limit()
+    try:
+        response = requests.get(
+            "https://nominatim.openstreetmap.org/search",
+            params={"format": "json", "q": sanitized},
+            headers={"User-Agent": _USER_AGENT},
+            timeout=10,
+        )
+    except requests.RequestException as exc:  # pragma: no cover - network failures
+        logger.warning("Geocoding request failed: %s", exc)
+        return None
+
+    if response.status_code == 429:
+        logger.warning("Geocoding rate limited by provider (429)")
+        return None
+    if not response.ok:
+        logger.warning("Geocoding request failed with status %s", response.status_code)
+        return None
+
+    try:
+        payload = response.json()
+    except ValueError:  # pragma: no cover - unexpected response
+        logger.warning("Failed to decode geocoding response as JSON")
+        return None
+
+    if not payload:
+        return None
+
+    first = payload[0]
+    try:
+        latitude = float(first["lat"])
+        longitude = float(first["lon"])
+    except (KeyError, TypeError, ValueError):
+        logger.warning("Invalid geocoding payload: %s", first)
+        return None
+
+    return latitude, longitude, first
+
+
+async def geocode(session: AsyncSession, address: str) -> tuple[float, float] | None:
+    """Geocode an address with caching and provider lookup."""
+
+    sanitized = sanitize_address(address)
+    if len(sanitized) < 5:
+        logger.info("skip: insufficient address (%s)", address)
+        return None
+
+    cached = await get_cached(session, sanitized)
+    if cached is not None:
+        return cached
+
+    try:
+        result = await asyncio.to_thread(nominatim_geocode, sanitized)
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Geocoding thread execution failed")
+        return None
+
+    if result is None:
+        return None
+
+    latitude, longitude, raw = result
+    await put_cache(session, sanitized, latitude, longitude, _PROVIDER, raw)
+    return latitude, longitude

--- a/migrations/versions/c7cf8e913d2a_add_geocode_cache_table.py
+++ b/migrations/versions/c7cf8e913d2a_add_geocode_cache_table.py
@@ -1,0 +1,51 @@
+"""Add geocode cache table.
+
+Revision ID: c7cf8e913d2a
+Revises: f4d2c1b3a789
+Create Date: 2024-05-01 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Alembic identifiers
+revision: str = "c7cf8e913d2a"
+down_revision: str | Sequence[str] | None = "f4d2c1b3a789"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "geocode_caches",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("address", sa.Text(), nullable=False),
+        sa.Column("latitude", sa.Float(), nullable=True),
+        sa.Column("longitude", sa.Float(), nullable=True),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("raw", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            server_onupdate=sa.func.now(),
+        ),
+        sa.UniqueConstraint("address", name="uq_geocode_caches_address"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("geocode_caches")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,8 @@ pytest-asyncio>=0.23
 pytest-mock>=3.12
 Faker>=19.0
 httpx>=0.27
+requests>=2.31
 anyio>=4.0
 eval_type_backport>=0.2
 beautifulsoup4>=4.12,<5
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ asyncpg>=0.28
 pytest>=7.4
 pytest-asyncio>=0.23
 httpx>=0.27
+requests>=2.31
 pydantic==2.8.2
 pydantic-core==2.20.1
 greenlet==3.2.4

--- a/scripts/ingest/cli.py
+++ b/scripts/ingest/cli.py
@@ -125,6 +125,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Number of items to process",
     )
+    normalize_parser.add_argument(
+        "--geocode-missing",
+        action="store_true",
+        help="Also geocode candidates lacking coordinates",
+    )
 
     approve_parser = subparsers.add_parser(
         "approve", help="Approve a gym candidate (dummy implementation)"
@@ -172,7 +177,14 @@ def _dispatch(args: argparse.Namespace) -> int:
     if command == "parse":
         return asyncio.run(_run_async_command(parse_pages, args.source, args.limit))
     if command == "normalize":
-        return asyncio.run(_run_async_command(normalize_candidates, args.source, args.limit))
+        return asyncio.run(
+            _run_async_command(
+                normalize_candidates,
+                args.source,
+                args.limit,
+                geocode_missing=args.geocode_missing,
+            )
+        )
     if command == "approve":
         return asyncio.run(_run_async_command(approve_candidate, args.candidate_id, args.dry_run))
     msg = f"Unknown command: {command}"

--- a/scripts/tools/__init__.py
+++ b/scripts/tools/__init__.py
@@ -1,0 +1,5 @@
+"""Utility scripts for maintenance tasks."""
+
+from .geocode_missing import main
+
+__all__ = ["main"]

--- a/scripts/tools/geocode_missing.py
+++ b/scripts/tools/geocode_missing.py
@@ -1,0 +1,164 @@
+"""CLI utilities for geocoding missing coordinates."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from collections.abc import Sequence
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import SessionLocal
+from app.models.gym import Gym
+from app.models.gym_candidate import GymCandidate
+from app.services.geocode import geocode
+
+logger = logging.getLogger(__name__)
+
+_TARGET_CHOICES = {"gyms", "candidates"}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Geocode missing gym coordinates")
+    parser.add_argument(
+        "--target",
+        choices=sorted(_TARGET_CHOICES),
+        required=True,
+        help="Target table to update (gyms or candidates)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of records to process",
+    )
+    return parser
+
+
+async def _load_records(
+    session: AsyncSession, target: str, limit: int | None
+) -> list[Gym | GymCandidate]:
+    if target == "gyms":
+        query = (
+            select(Gym)
+            .where(or_(Gym.latitude.is_(None), Gym.longitude.is_(None)))
+            .where(Gym.address.isnot(None))
+            .order_by(Gym.id)
+        )
+    elif target == "candidates":
+        query = (
+            select(GymCandidate)
+            .where(or_(GymCandidate.latitude.is_(None), GymCandidate.longitude.is_(None)))
+            .where(GymCandidate.address_raw.isnot(None))
+            .order_by(GymCandidate.id)
+        )
+    else:  # pragma: no cover - validation should prevent this
+        msg = f"Unsupported target: {target}"
+        raise ValueError(msg)
+
+    if limit is not None:
+        query = query.limit(limit)
+
+    result = await session.execute(query)
+    return list(result.scalars().all())
+
+
+async def _process_records(session: AsyncSession, target: str, limit: int | None) -> dict[str, int]:
+    records = await _load_records(session, target, limit)
+    if not records:
+        logger.info("No %s with missing coordinates", target)
+        return {"tried": 0, "updated": 0, "skipped": 0}
+
+    tried = 0
+    updated = 0
+    skipped = 0
+
+    for record in records:
+        tried += 1
+        address = record.address if target == "gyms" else record.address_raw
+        if not address:
+            skipped += 1
+            logger.info("Skipping id=%s due to missing address", record.id)
+            continue
+
+        coords = await geocode(session, address)
+        if coords is None:
+            skipped += 1
+            continue
+
+        latitude, longitude = coords
+        changed = False
+        if getattr(record, "latitude") is None and latitude is not None:
+            record.latitude = latitude
+            changed = True
+        if getattr(record, "longitude") is None and longitude is not None:
+            record.longitude = longitude
+            changed = True
+
+        if changed:
+            updated += 1
+            await session.flush()
+            logger.info(
+                "Updated %s id=%s with lat=%s lon=%s",
+                target[:-1],
+                record.id,
+                latitude,
+                longitude,
+            )
+        else:
+            skipped += 1
+
+    return {"tried": tried, "updated": updated, "skipped": skipped}
+
+
+async def geocode_missing_records(
+    target: str, limit: int | None = None, session: AsyncSession | None = None
+) -> dict[str, int]:
+    """Geocode missing coordinates for gyms or candidates."""
+
+    if target not in _TARGET_CHOICES:
+        msg = f"Invalid target: {target}"
+        raise ValueError(msg)
+
+    if session is None:
+        async with SessionLocal() as owned_session:
+            summary = await _process_records(owned_session, target, limit)
+            await owned_session.commit()
+            logger.info(
+                "Finished geocoding %s: tried=%s, updated=%s, skipped=%s",
+                target,
+                summary["tried"],
+                summary["updated"],
+                summary["skipped"],
+            )
+            return summary
+
+    summary = await _process_records(session, target, limit)
+    logger.info(
+        "Finished geocoding %s: tried=%s, updated=%s, skipped=%s",
+        target,
+        summary["tried"],
+        summary["updated"],
+        summary["skipped"],
+    )
+    return summary
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        summary = asyncio.run(geocode_missing_records(args.target, args.limit))
+    except Exception:  # pragma: no cover - CLI safeguard
+        logger.exception("Geocoding script failed")
+        return 1
+
+    logger.info("Summary: %s", summary)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,7 @@ async def app_client(monkeypatch):
 async def engine():
     eng = create_async_engine(DB_URL, **_engine_kwargs(DB_URL))
     # モデルを確実に import してメタデータを埋める
-    for m in ("source", "gym", "equipment", "gym_equipment", "report"):
+    for m in ("source", "gym", "equipment", "gym_equipment", "report", "geocode_cache"):
         try:
             importlib.import_module(f"app.models.{m}")
         except Exception:

--- a/tests/test_geocode_cache.py
+++ b/tests/test_geocode_cache.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.models.gym import Gym
+from app.services import geocode as geocode_service
+from scripts.tools import geocode_missing
+
+
+@pytest.mark.asyncio
+async def test_geocode_uses_cache(session, monkeypatch):
+    calls = 0
+
+    def fake_nominatim(address: str):
+        nonlocal calls
+        calls += 1
+        return 35.0, 139.0, {"lat": "35.0", "lon": "139.0"}
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(geocode_service, "nominatim_geocode", fake_nominatim)
+    monkeypatch.setattr(geocode_service.asyncio, "to_thread", fake_to_thread)
+
+    address = "東京都千代田区千代田1-1"
+
+    result1 = await geocode_service.geocode(session, address)
+    assert result1 == (35.0, 139.0)
+    assert calls == 1
+
+    result2 = await geocode_service.geocode(session, address)
+    assert result2 == (35.0, 139.0)
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_geocode_missing_updates_records(session, monkeypatch):
+    gym = Gym(
+        name="Geocode Test Gym",
+        slug="geocode-test-gym",
+        canonical_id=str(uuid.uuid4()),
+        address="東京都千代田区千代田1-1",
+    )
+    session.add(gym)
+    await session.flush()
+
+    async def fake_geocode(_, address: str):
+        assert address
+        return 34.1234, 135.5678
+
+    monkeypatch.setattr(geocode_missing, "geocode", fake_geocode)
+
+    summary = await geocode_missing.geocode_missing_records("gyms", limit=10, session=session)
+
+    await session.refresh(gym)
+
+    assert summary == {"tried": 1, "updated": 1, "skipped": 0}
+    assert gym.latitude == pytest.approx(34.1234)
+    assert gym.longitude == pytest.approx(135.5678)


### PR DESCRIPTION
## 目的
- ジム/候補の緯度経度欠損を住所から補完しAPI負荷を抑えるため

## 変更点
- geocode_caches テーブルとモデルを追加し、Nominatim ベースのキャッシュを導入
- geocode サービスと欠損補完スクリプト `scripts/tools/geocode_missing.py` を追加
- 正規化処理にオプションのジオコーディング実行と依存ライブラリ・テストを整備

## 確認手順
- [x] `ruff format .`
- [x] `ruff check .`
- [x] `pytest`

## CI
- [ ] GitHub Actions が全て成功

------
https://chatgpt.com/codex/tasks/task_e_68e32085ce70832a80ea5891c94b363a